### PR TITLE
Add module checking media library limits in Azure

### DIFF
--- a/KInspector.Modules/KInspector.Modules.csproj
+++ b/KInspector.Modules/KInspector.Modules.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Modules\Content\RobotsTxtModule.cs" />
     <Compile Include="Modules\Content\WebPartsInTemplatesAndTransformationsModule.cs" />
     <Compile Include="Modules\EventLog\EventLogErrorsModule.cs" />
+    <Compile Include="Modules\General\MediaLibraryAzureLimitModule.cs" />
     <Compile Include="Modules\General\DatabaseConsistencyCheckModule.cs" />
     <Compile Include="Modules\General\BigTablesAzureModule.cs" />
     <Compile Include="Modules\Content\WebPartColumnsModule.cs" />
@@ -161,6 +162,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="ProbeData\CMSPages\KInspectorProbe.aspx">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Scripts\MediaLibraryAzureLimitModule.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Scripts\TransformationAnalyzerModule-TransformationCodes.sql">

--- a/KInspector.Modules/Modules/General/MediaLibraryAzureLimitModule.cs
+++ b/KInspector.Modules/Modules/General/MediaLibraryAzureLimitModule.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using KInspector.Core;
+
+namespace KInspector.Modules.Modules.General
+{
+    public class MediaLibraryAzureLimitModule : IModule
+    {
+        public ModuleMetadata GetModuleMetadata()
+        {
+            return new ModuleMetadata
+            { 
+                Name = "Maximum 100 files per folder in Azure Blob storage",
+                SupportedVersions = new[] {
+                    new Version("6.0"),
+                    new Version("7.0"),
+                    new Version("8.0"), 
+                    new Version("8.1"), 
+                    new Version("8.2") 
+                },
+                Category = "Performance",
+                Comment = @"Web sites utilizing Azure Blob storage should limit media library folder size to maximum 100 items per folder to achieve good performance.",
+            };
+        }
+
+
+        public ModuleResults GetResults(InstanceInfo instanceInfo, DatabaseService dbService)
+        {
+            var results = dbService.ExecuteAndGetTableFromFile("MediaLibraryAzureLimitModule.sql");
+
+            if (results.Rows.Count > 0)
+            {
+                return new ModuleResults()
+                {
+                    Result = results,
+                    ResultComment = "Some of your media library folders contains more than 100 items. If your website is utilizing Azure Blob storage, you should rearrange your folders to improve the performance.",
+                    Status = Status.Warning
+                };
+            }
+
+            return new ModuleResults
+            {
+                Result = "None of your media library folders contains more than 100 items.",
+                Status = Status.Good
+            };
+        }
+    }
+}

--- a/KInspector.Modules/Scripts/MediaLibraryAzureLimitModule.sql
+++ b/KInspector.Modules/Scripts/MediaLibraryAzureLimitModule.sql
@@ -1,0 +1,15 @@
+﻿-- File parent folder path is used to group items. 
+-- This path is calcualted from FilePath field by removing the file part.
+-- Example: 
+-- /somefolder/subfolder/filename.ext -> /somefolder/subfolder
+-- /filename.ext -> '' (empty string)
+SELECT LibraryDisplayName as [Library name],
+	SUBSTRING('/' + f.FilePath, 0, LEN('/' + f.FilePath) - CHARINDEX('/', REVERSE('/' + f.FilePath)) + 1) as [Folder Name], 
+	SiteName as [Site name],
+	COUNT(*) as [Number of files]
+FROM Media_File AS f 
+INNER JOIN Media_Library AS l ON f.FileLibraryID = l.LibraryID 
+INNER JOIN CMS_Site AS s ON s.SiteID = l.LibrarySiteID
+GROUP BY SUBSTRING('/' + f.FilePath, 0, LEN('/' + f.FilePath) - CHARINDEX('/', REVERSE('/' + f.FilePath)) + 1), LibraryDisplayName, SiteName
+HAVING COUNT(*) > 100
+ORDER BY LibraryDisplayName


### PR DESCRIPTION
Based on the issue #24 

###### Approach
I've trimmed file name from the file path and grouped those records together 
(e.g.: ```/somefolder/subfolder/filename.ext``` -> ```/somefolder/subfolder```)

 All records having more than 100 rows are displayed to the user for further actions.

Anything to improve? Thanks