### PR TITLE
Get rid of TODO in DatabaseConsistencyCheckModule

### DIFF
--- a/KInspector.Core/DatabaseService.cs
+++ b/KInspector.Core/DatabaseService.cs
@@ -57,7 +57,15 @@ namespace KInspector.Core
         /// </remarks>
         private DataTable ExecuteAndGetTable(string sql, params SqlParameter[] parameters)
         {
-            return ExecuteAndGetDataSet(sql, parameters).Tables[0];
+            DataSet result = ExecuteAndGetDataSet(sql, parameters);
+            if (result.Tables.Count > 0)
+            {
+                return result.Tables[0];
+            }
+            else
+            {
+                return new DataTable();
+            }
         }
 
 

--- a/KInspector.Modules/Modules/General/DatabaseConsistencyCheckModule.cs
+++ b/KInspector.Modules/Modules/General/DatabaseConsistencyCheckModule.cs
@@ -17,7 +17,7 @@ namespace KInspector.Modules.Modules.General
                     new Version("8.1"), 
                     new Version("8.2") 
                 },
-                Comment = @"Runs DBCC CHECKDB on current database which checks all consistency issues.",
+                Comment = @"Runs DBCC CHECKDB on current database which checks all consistency issues (https://msdn.microsoft.com/en-us/library/ms176064.aspx).",
                 Category = "Consistency issues"
             };
         }
@@ -25,26 +25,23 @@ namespace KInspector.Modules.Modules.General
 
         public ModuleResults GetResults(InstanceInfo instanceInfo, DatabaseService dbService)
         {
-            try
-            {
-                var results = dbService.ExecuteAndGetTableFromFile("DatabaseConsistencyCheckModule.sql");
+            var results = dbService.ExecuteAndGetTableFromFile("DatabaseConsistencyCheckModule.sql");
 
-                return new ModuleResults
-                {
-                    Result = results,
-                    Status =  Status.Error
-                };
-            }
-            //TODO: temporary fix for dbService api
-            // If no error is found, than no table is returned and dbService throws exception.
-            catch (IndexOutOfRangeException)
+            if (results.Rows.Count > 0)
             {
                 return new ModuleResults
                 {
-                    Status = Status.Good,
-                    ResultComment = "CHECKDB didn't found any errors."
+                    ResultComment = "CHECKDB found some errors!",
+                    Result = results,
+                    Status = Status.Error
                 };
             }
+
+            return new ModuleResults
+            {
+                Status = Status.Good,
+                ResultComment = "CHECKDB didn't found any errors."
+            };
         }
     }
 }


### PR DESCRIPTION
Method ExecuteAndGetTable new returns empty DataTable
if there is no output from the SQL Server. That means
there is no need for try/catch in
DatabaseConsistencyCheckModule.

Our implementation threw an exception if there was no
output from SQL Server. It was caused because there was
no check for table existence in DataSet.