### PR TITLE
Add a simple FAKE build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,6 @@ FakesAssemblies/
 GeneratedArtifacts/
 _Pvt_Extensions/
 ModelManifest.xml
+
+# FAKE
+.fake/

--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
 @echo off
-".nuget\NuGet.exe" "Install" "FAKE.Core" "-OutputDirectory" "packages" "-ExcludeVersion"
+".nuget\NuGet.exe" "Install" "FAKE.Core" "-OutputDirectory" "packages" "-ExcludeVersion" "-Source" "https://www.nuget.org/api/v2"
 "packages\FAKE.Core\tools\Fake.exe" build.fsx
 pause

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,4 @@
+@echo off
+".nuget\NuGet.exe" "Install" "FAKE.Core" "-OutputDirectory" "packages" "-ExcludeVersion"
+"packages\FAKE.Core\tools\Fake.exe" build.fsx
+pause

--- a/build.fsx
+++ b/build.fsx
@@ -1,0 +1,25 @@
+#r @"packages/FAKE/tools/FakeLib.dll"
+open Fake
+
+// Properties
+let outputDir = "./Bin/"
+
+// Targets
+Target "Clean" (fun _ ->
+    CleanDir outputDir
+)
+
+Target "Compile" (fun _ ->
+    !!"./KInspector.sln"
+    |> MSBuildRelease "" "Rebuild"
+    |> ignore
+)
+
+Target "Default" DoNothing
+
+// Dependencies
+"Clean"
+  ==> "Compile"
+  ==> "Default"
+
+RunTargetOrDefault "Default"

--- a/build.fsx
+++ b/build.fsx
@@ -13,11 +13,11 @@ Target "Clean" (fun _ ->
 )
 
 Target "RestorePackages" (fun _ ->
-  slnFile
-   |> RestoreMSSolutionPackages (fun p ->
-       { p with
-           Sources = defaultPackageSource :: p.Sources
-       })
+    slnFile
+    |> RestoreMSSolutionPackages (fun p ->
+        { p with
+            Sources = defaultPackageSource :: p.Sources
+        })
 )
 
 Target "Compile" (fun _ ->

--- a/build.fsx
+++ b/build.fsx
@@ -1,16 +1,27 @@
-#r @"packages/FAKE/tools/FakeLib.dll"
+#r @"packages/FAKE.Core/tools/FakeLib.dll"
 open Fake
 
 // Properties
 let outputDir = "./Bin/"
+let slnFile = "./KInspector.sln"
+
+let defaultPackageSource = "https://www.nuget.org/api/v2"
 
 // Targets
 Target "Clean" (fun _ ->
     CleanDir outputDir
 )
 
+Target "RestorePackages" (fun _ ->
+  slnFile
+   |> RestoreMSSolutionPackages (fun p ->
+       { p with
+           Sources = defaultPackageSource :: p.Sources
+       })
+)
+
 Target "Compile" (fun _ ->
-    !!"./KInspector.sln"
+    !!slnFile
     |> MSBuildRelease "" "Rebuild"
     |> ignore
 )
@@ -19,6 +30,7 @@ Target "Default" DoNothing
 
 // Dependencies
 "Clean"
+  ==> "RestorePackages"
   ==> "Compile"
   ==> "Default"
 


### PR DESCRIPTION
I've added a very simple [FAKE](http://fsharp.github.io/FAKE/) build script to simplify the use of the analyzer tool. Just run `build.cmd` and get the artifacts without starting Visual Studio or something else.