### PR TITLE
Adjust namespace in `KInspectorProbe.aspx`

### DIFF
--- a/KInspector.Modules/KInspector.Modules.csproj
+++ b/KInspector.Modules/KInspector.Modules.csproj
@@ -163,6 +163,7 @@
   <ItemGroup>
     <Content Include="ProbeData\CMSPages\KInspectorProbe.aspx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>ASPXCodeBehind</SubType>
     </Content>
     <Content Include="Scripts\MediaLibraryAzureLimitModule.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/KInspector.Modules/ProbeData/CMSPages/KInspectorProbe.aspx.cs
+++ b/KInspector.Modules/ProbeData/CMSPages/KInspectorProbe.aspx.cs
@@ -14,7 +14,7 @@ using System.Data;
 using System.IO;
 
 
-namespace CMSApp.CMSPages
+namespace KInspector.Modules.ProbeData.CMSPages
 {
     /// <summary>
     /// Prints auditing information about the instance.

--- a/KInspector.Modules/ProbeData/CMSPages/KInspectorProbe.aspx.designer.cs
+++ b/KInspector.Modules/ProbeData/CMSPages/KInspectorProbe.aspx.designer.cs
@@ -7,9 +7,9 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace CMSApp.CMSPages {
-    
-    
-    public partial class KInspectorProbe {
+namespace KInspector.Modules.ProbeData.CMSPages
+{
+    public partial class KInspectorProbe
+    {
     }
 }


### PR DESCRIPTION
When running the `General` -> `Cache items` module an exception was thrown because the namespaces were not matching:

    System.Net.WebException: The remote server returned an error: (500) Internal Server Error.
     at System.Net.HttpWebRequest.GetResponse()
     at KInspector.Modules.Modules.General.CacheItemsModule.GetResults(InstanceInfo instanceInfo, DatabaseService dbService) in c:\Projects\KInspector\KInspector.Modules\Modules\General\CacheItemsModule.cs:line 34