### PR TITLE
Fix support for virtual path URLs

### DIFF
--- a/KInspector.Core/InstanceInfo.cs
+++ b/KInspector.Core/InstanceInfo.cs
@@ -80,7 +80,21 @@ namespace Kentico.KInspector.Core
 
             dbService = new Lazy<DatabaseService>(() => new DatabaseService(Config));
             version = new Lazy<Version>(() => GetKenticoVersion());
-            uri = new Lazy<Uri>(() => new Uri(Config.Url));
+
+            // Ensure backslash to the Config.Url to support VirtualPath URLs.
+            // Sometimes the website is running under virtual path and 
+            // the URL looks like this http://localhost/kentico8
+            // Some modules (RobotsTxtModule, CacheItemsModle, ...) try 
+            // to append the relative path to the base URL but
+            // without trailing slash, the relative path is replaced.
+            // E.g.: 
+            //      var uri = new Uri("http://localhost/kentico8");
+            //      new Uri(uri, "robots.txt"); -> http://localhost/robots.txt
+            // 
+            // With trailing slash, the relative path is appended as expected.
+            //      var uri = new Uri("http://localhost/kentico8/");
+            //      new Uri(uri, "robots.txt"); -> http://localhost/kentico8/robots.txt
+            uri = new Lazy<Uri>(() => new Uri(Config.Url.EndsWith("/") ? Config.Url : Config.Url + "/"));
             directory = new Lazy<DirectoryInfo>(() => new DirectoryInfo(Config.Path));
         }
 

--- a/KInspector.Tests/InstanceInfoTests.cs
+++ b/KInspector.Tests/InstanceInfoTests.cs
@@ -1,0 +1,26 @@
+﻿using Kentico.KInspector.Core;
+using Kentico.KInspector.Modules;
+using NUnit.Framework;
+
+namespace Kentico.KInspector.Tests
+{
+    [TestFixture]
+    public class InstanceInfoTests
+    {
+        [TestCase("http://relative.url", "http://relative.url/")]
+        [TestCase("http://relative.url/", "http://relative.url/")]
+        [TestCase("http://relative.url/nobackslash", "http://relative.url/nobackslash/")]
+        [TestCase("http://relative.url/backslash/", "http://relative.url/backslash/")]
+        public void EnsureTrailingSlash(string url, string expected)
+        {
+            var instanceConfig = new InstanceConfig()
+            {
+                Url = url
+            };
+            
+            var instanceInfo = new InstanceInfo(instanceConfig);
+
+            Assert.AreEqual(expected, instanceInfo.Uri.AbsoluteUri);
+        }
+    }
+}

--- a/KInspector.Tests/Kentico.KInspector.Tests.csproj
+++ b/KInspector.Tests/Kentico.KInspector.Tests.csproj
@@ -60,6 +60,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="InstanceInfoTests.cs" />
     <Compile Include="UIElementsDiffTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fix for the issue #57 

Sometimes the website is running under virtual path and the URL looks like this ```http://localhost/kentico8```
Some modules (RobotsTxtModule, CacheItemsModle, ...) try to append the relative path to the base URL but without trailing slash, the relative path is replaced.
E.g.:
```
var uri = new Uri("http://localhost/kentico8");
new Uri(uri, "robots.txt"); // http://localhost/robots.txt
```
With trailing slash, the relative path is appended as expected.
```
var uri = new Uri("http://localhost/kentico8/");
new Uri(uri, "robots.txt"); // http://localhost/kentico8/robots.txt
```