### PR TITLE
Delete NuGet.Config

### DIFF
--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <solution>
-    <add key="disableSourceControlIntegration" value="true" />
-  </solution>
-</configuration>


### PR DESCRIPTION
Don't need it anymore. The only setting we use is TFS specific.