### PR TITLE
Changes to facilitate Unit Testing of Modules

### DIFF
--- a/KInspector.Core/DatabaseService.cs
+++ b/KInspector.Core/DatabaseService.cs
@@ -9,7 +9,7 @@ namespace Kentico.KInspector.Core
     /// <summary>
     /// Basic service for communication with database.
     /// </summary>
-    public class DatabaseService
+    public class DatabaseService : IDatabaseService
     {
         private readonly string mConnectionString;
         private const int SQL_COMMAND_TIMEOUT_SECONDS = 90;

--- a/KInspector.Core/IDatabaseService.cs
+++ b/KInspector.Core/IDatabaseService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+namespace Kentico.KInspector.Core
+{
+    public interface IDatabaseService
+    {
+        System.Data.DataSet ExecuteAndGetDataSetFromFile(string filePath);
+        System.Collections.Generic.List<string> ExecuteAndGetPrintsFromFile(string filePath);
+        T ExecuteAndGetScalar<T>(string sql) where T : IConvertible;
+        System.Data.DataTable ExecuteAndGetTableFromFile(string filePath, params System.Data.SqlClient.SqlParameter[] parameters);
+        T GetSetting<T>(string key, string siteName = "") where T : IConvertible;
+    }
+}

--- a/KInspector.Core/IInstanceInfo.cs
+++ b/KInspector.Core/IInstanceInfo.cs
@@ -1,0 +1,12 @@
+﻿using System;
+namespace Kentico.KInspector.Core
+{
+    public interface IInstanceInfo
+    {
+        InstanceConfig Config { get; }
+        IDatabaseService DBService { get; }
+        System.IO.DirectoryInfo Directory { get; }
+        Uri Uri { get; }
+        Version Version { get; }
+    }
+}

--- a/KInspector.Core/IModule.cs
+++ b/KInspector.Core/IModule.cs
@@ -44,6 +44,6 @@
         /// }
         /// </code> 
         /// </example>
-        ModuleResults GetResults(InstanceInfo instanceInfo);
+        ModuleResults GetResults(IInstanceInfo instanceInfo);
     }
 }

--- a/KInspector.Core/InstanceInfo.cs
+++ b/KInspector.Core/InstanceInfo.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 namespace Kentico.KInspector.Core
 {
-    public class InstanceInfo
+    public class InstanceInfo : IInstanceInfo
     {
         private Lazy<DatabaseService> dbService;
         private Lazy<Version> version;
@@ -56,7 +56,7 @@ namespace Kentico.KInspector.Core
         /// <summary>
         /// Database service to communicate with the instance database.
         /// </summary>
-        public DatabaseService DBService
+        public IDatabaseService DBService
         {
             get
             {

--- a/KInspector.Core/Kentico.KInspector.Core.csproj
+++ b/KInspector.Core/Kentico.KInspector.Core.csproj
@@ -55,6 +55,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IDatabaseService.cs" />
+    <Compile Include="IInstanceInfo.cs" />
     <Compile Include="InstanceConfig.cs" />
     <Compile Include="InstanceInfo.cs" />
     <Compile Include="IModule.cs" />

--- a/KInspector.Modules/Modules/Content/AttachmentsBySizeModule.cs
+++ b/KInspector.Modules/Modules/Content/AttachmentsBySizeModule.cs
@@ -29,7 +29,7 @@ https://docs.kentico.com/display/K82/Defining+website+data+structure#Definingweb
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("AttachmentsBySizeModule.sql");

--- a/KInspector.Modules/Modules/Content/DuplicatePageAliasesModule.cs
+++ b/KInspector.Modules/Modules/Content/DuplicatePageAliasesModule.cs
@@ -25,7 +25,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             DataSet results = dbService.ExecuteAndGetDataSetFromFile("DuplicatePageAliasesModule.sql");

--- a/KInspector.Modules/Modules/Content/PageTypeAssignedToSiteModule.cs
+++ b/KInspector.Modules/Modules/Content/PageTypeAssignedToSiteModule.cs
@@ -26,7 +26,7 @@ If the page type is not assigned to the site and is used by this site, you will 
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("PageTypeAssignedToSiteModule.sql");

--- a/KInspector.Modules/Modules/Content/RobotsTxtModule.cs
+++ b/KInspector.Modules/Modules/Content/RobotsTxtModule.cs
@@ -24,7 +24,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             if (!TestUrl(instanceInfo.Uri, "robots.txt"))
             {

--- a/KInspector.Modules/Modules/Content/SiteTemplatesModule.cs
+++ b/KInspector.Modules/Modules/Content/SiteTemplatesModule.cs
@@ -73,7 +73,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var webPartsWithColumns = dbService.ExecuteAndGetTableFromFile("SiteTemplatesModule-WebPartsWithColumns.sql");

--- a/KInspector.Modules/Modules/Content/TreeNodeChildrenModule.cs
+++ b/KInspector.Modules/Modules/Content/TreeNodeChildrenModule.cs
@@ -25,7 +25,7 @@ Our best practice is to store under each TreeNode maximum of 1000 children, othe
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("TreeNodeChildrenModule.sql");

--- a/KInspector.Modules/Modules/Content/WebPartColumnsModule.cs
+++ b/KInspector.Modules/Modules/Content/WebPartColumnsModule.cs
@@ -27,7 +27,7 @@ https://docs.kentico.com/display/K82/Loading+data+efficiently",
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             if (instanceInfo.Version == new Version("6.0"))

--- a/KInspector.Modules/Modules/Content/WebPartsInTransformationsModule.cs
+++ b/KInspector.Modules/Modules/Content/WebPartsInTransformationsModule.cs
@@ -33,7 +33,7 @@ You should use hierarchical transformation instead (see https://docs.kentico.com
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("WebPartsInTransformationsModule.sql");

--- a/KInspector.Modules/Modules/EventLog/ApplicationRestartsModule.cs
+++ b/KInspector.Modules/Modules/EventLog/ApplicationRestartsModule.cs
@@ -25,7 +25,7 @@ Frequent restarts could signify some troubles.",
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("ApplicationRestartsModule.sql");

--- a/KInspector.Modules/Modules/EventLog/EventLogErrorsModule.cs
+++ b/KInspector.Modules/Modules/EventLog/EventLogErrorsModule.cs
@@ -26,7 +26,7 @@ Sometimes it's not possible to avoid all the errors, but that should be an excep
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("EventLogErrorsModule.sql");

--- a/KInspector.Modules/Modules/EventLog/PageNotFoundsModule.cs
+++ b/KInspector.Modules/Modules/EventLog/PageNotFoundsModule.cs
@@ -29,7 +29,7 @@ For the complete website analysis, you can use an external tool like www.deadlin
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("PageNotFoundsModule.sql");

--- a/KInspector.Modules/Modules/General/BigTablesModule.cs
+++ b/KInspector.Modules/Modules/General/BigTablesModule.cs
@@ -23,7 +23,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
 

--- a/KInspector.Modules/Modules/General/CMSFileModule.cs
+++ b/KInspector.Modules/Modules/General/CMSFileModule.cs
@@ -21,7 +21,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetPrintsFromFile("CMSFileModule.sql");

--- a/KInspector.Modules/Modules/General/CacheItemsModule.cs
+++ b/KInspector.Modules/Modules/General/CacheItemsModule.cs
@@ -23,7 +23,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             try
             {

--- a/KInspector.Modules/Modules/General/DatabaseConsistencyCheckModule.cs
+++ b/KInspector.Modules/Modules/General/DatabaseConsistencyCheckModule.cs
@@ -24,7 +24,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("DatabaseConsistencyCheckModule.sql");

--- a/KInspector.Modules/Modules/General/DocumentsConsistencyIssuesModule.cs
+++ b/KInspector.Modules/Modules/General/DocumentsConsistencyIssuesModule.cs
@@ -25,7 +25,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             DataSet results = dbService.ExecuteAndGetDataSetFromFile("DocumentsConsistencyIssuesModule.sql");

--- a/KInspector.Modules/Modules/General/InstanceInfoModule.cs
+++ b/KInspector.Modules/Modules/General/InstanceInfoModule.cs
@@ -20,7 +20,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetDataSetFromFile("InstanceInfo.sql");

--- a/KInspector.Modules/Modules/General/MediaLibraryAzureLimitModule.cs
+++ b/KInspector.Modules/Modules/General/MediaLibraryAzureLimitModule.cs
@@ -24,7 +24,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("MediaLibraryAzureLimitModule.sql");

--- a/KInspector.Modules/Modules/General/PagesAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/General/PagesAnalyzerModule.cs
@@ -64,7 +64,7 @@ Note: Although it may seem that touch icon is for Apple devices only, this is no
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var siteID = dbService.ExecuteAndGetScalar<int>(string.Format(@"SELECT s.SiteID FROM CMS_Site AS s LEFT JOIN CMS_SiteDomainAlias AS sa ON s.SiteID = sa.SiteID 

--- a/KInspector.Modules/Modules/General/ScheduledTasksModule.cs
+++ b/KInspector.Modules/Modules/General/ScheduledTasksModule.cs
@@ -24,7 +24,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetPrintsFromFile("ScheduledTasksModule.sql");

--- a/KInspector.Modules/Modules/General/ScreenshotterModule.cs
+++ b/KInspector.Modules/Modules/General/ScreenshotterModule.cs
@@ -31,7 +31,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var urls = dbService.ExecuteAndGetTableFromFile("ScreenshotterModule.sql");

--- a/KInspector.Modules/Modules/General/SettingsModule.cs
+++ b/KInspector.Modules/Modules/General/SettingsModule.cs
@@ -23,7 +23,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("SettingsModule.sql");

--- a/KInspector.Modules/Modules/General/SiteMapModule.cs
+++ b/KInspector.Modules/Modules/General/SiteMapModule.cs
@@ -40,7 +40,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var sitemaps = dbService.ExecuteAndGetDataSetFromFile("SiteMapModule.sql");

--- a/KInspector.Modules/Modules/General/UIElementsDiff.cs
+++ b/KInspector.Modules/Modules/General/UIElementsDiff.cs
@@ -25,7 +25,7 @@ namespace Kentico.KInspector.Modules
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             DataTable sourceUIElements = dbService.ExecuteAndGetTableFromFile(String.Format("UIElementsDiffV{0}.sql", instanceInfo.Version.Major));

--- a/KInspector.Modules/Modules/OnlineMarketing/OMContactGroupsWithManualMacro.cs
+++ b/KInspector.Modules/Modules/OnlineMarketing/OMContactGroupsWithManualMacro.cs
@@ -23,7 +23,7 @@ NOTE: This applies only on Kentico 8.1 and above, where the improvements were in
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var manualContactGroups = dbService.ExecuteAndGetTableFromFile("OMContactGroupsWithManualMacro.sql");

--- a/KInspector.Modules/Modules/OnlineMarketing/OMInactiveContactsDeletion.cs
+++ b/KInspector.Modules/Modules/OnlineMarketing/OMInactiveContactsDeletion.cs
@@ -23,7 +23,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var contactNumber = dbService.ExecuteAndGetScalar<int>(@"SELECT COUNT(*) FROM OM_Contact");

--- a/KInspector.Modules/Modules/OnlineMarketing/OMNewslettersWithoutQueue.cs
+++ b/KInspector.Modules/Modules/OnlineMarketing/OMNewslettersWithoutQueue.cs
@@ -23,7 +23,7 @@ Default app pool recycle is every 29 hours. If you're sending a lot of emails, t
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var newslettersWithDisabledQueue = dbService.ExecuteAndGetTableFromFile("OMNewslettersWithoutQueue.sql");

--- a/KInspector.Modules/Modules/OnlineMarketing/OMTablesSize.cs
+++ b/KInspector.Modules/Modules/OnlineMarketing/OMTablesSize.cs
@@ -28,7 +28,7 @@ Checks the following:
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             List<string> responses = new List<string>();
 

--- a/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
+++ b/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
@@ -36,38 +36,36 @@ This module also checks that there is a password policy enforced to ensure users
             var results = dbService.ExecuteAndGetTableFromFile("PasswordPolicy.sql");
 
             if (results.Rows.Count > 0)
-            {
+            { 
                 DataRow[] passwordFormatRow = results.Select("KeyName = 'CMSPasswordFormat'");
-                DataRow[] passwordPolicyRows = results.Select("KeyName = 'CMSUsePasswordPolicy'");
+                DataRow[] passwordPolicyRow = results.Select("KeyName = 'CMSUsePasswordPolicy'");
 
                 if (passwordFormatRow[0][1].ToString() != "SHA2SALT")
-                        {
-                            return new ModuleResults
-                            {
-                                Result = results,
-                                ResultComment = "The CMSPasswordFormat should be set to 'SHA2SALT'.",
-                                Status = Status.Error,
-                            };
-                        } 
-
-                foreach (var passwordPolicyRow in passwordPolicyRows)
                 {
-                    if (passwordPolicyRow[1].ToString() != "True")
-                            {
-                                return new ModuleResults
-                                {
-                                    Result = results,
-                                    ResultComment = "It is recommended that you have CMSUsePasswordPolicy set to 'True'.",
-                                    Status = Status.Warning,
-                                };
-                            } 
+                    return new ModuleResults
+                    {
+                        Result = results,
+                        ResultComment = "The CMSPasswordFormat should be set to 'SHA2SALT'.",
+                        Status = Status.Error,
+                    };
                 }
-
-                return new ModuleResults
+                else if (passwordPolicyRow[0][1].ToString() != "True")
                 {
-                    ResultComment = "Password settings look good.",
-                    Status = Status.Good
-                };
+                    return new ModuleResults
+                    {
+                        Result = results,
+                        ResultComment = "It is recommended that you have CMSUsePasswordPolicy set to 'True'.",
+                        Status = Status.Warning,
+                    };
+                }
+                else
+                {
+                    return new ModuleResults
+                    {
+                        ResultComment = "Password settings look good.",
+                        Status = Status.Good
+                    };
+                }
             }
 
             return new ModuleResults

--- a/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
+++ b/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
@@ -36,36 +36,38 @@ This module also checks that there is a password policy enforced to ensure users
             var results = dbService.ExecuteAndGetTableFromFile("PasswordPolicy.sql");
 
             if (results.Rows.Count > 0)
-            { 
+            {
                 DataRow[] passwordFormatRow = results.Select("KeyName = 'CMSPasswordFormat'");
-                DataRow[] passwordPolicyRow = results.Select("KeyName = 'CMSUsePasswordPolicy'");
+                DataRow[] passwordPolicyRows = results.Select("KeyName = 'CMSUsePasswordPolicy'");
 
                 if (passwordFormatRow[0][1].ToString() != "SHA2SALT")
+                        {
+                            return new ModuleResults
+                            {
+                                Result = results,
+                                ResultComment = "The CMSPasswordFormat should be set to 'SHA2SALT'.",
+                                Status = Status.Error,
+                            };
+                        } 
+
+                foreach (var passwordPolicyRow in passwordPolicyRows)
                 {
-                    return new ModuleResults
-                    {
-                        Result = results,
-                        ResultComment = "The CMSPasswordFormat should be set to 'SHA2SALT'.",
-                        Status = Status.Error,
-                    };
+                    if (passwordPolicyRow[1].ToString() != "True")
+                            {
+                                return new ModuleResults
+                                {
+                                    Result = results,
+                                    ResultComment = "It is recommended that you have CMSUsePasswordPolicy set to 'True'.",
+                                    Status = Status.Warning,
+                                };
+                            } 
                 }
-                else if (passwordPolicyRow[0][1].ToString() != "True")
+
+                return new ModuleResults
                 {
-                    return new ModuleResults
-                    {
-                        Result = results,
-                        ResultComment = "It is recommended that you have CMSUsePasswordPolicy set to 'True'.",
-                        Status = Status.Warning,
-                    };
-                }
-                else
-                {
-                    return new ModuleResults
-                    {
-                        ResultComment = "Password settings look good.",
-                        Status = Status.Good
-                    };
-                }
+                    ResultComment = "Password settings look good.",
+                    Status = Status.Good
+                };
             }
 
             return new ModuleResults

--- a/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
+++ b/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
@@ -40,7 +40,7 @@ This module also checks that there is a password policy enforced to ensure users
                 DataRow[] passwordFormatRow = results.Select("KeyName = 'CMSPasswordFormat'");
                 DataRow[] passwordPolicyRows = results.Select("KeyName = 'CMSUsePasswordPolicy'");
 
-                if (passwordFormatRow[0][2].ToString() != "SHA2SALT")
+                if (passwordFormatRow[0][1].ToString() != "SHA2SALT")
                         {
                             return new ModuleResults
                             {
@@ -52,7 +52,7 @@ This module also checks that there is a password policy enforced to ensure users
 
                 foreach (var passwordPolicyRow in passwordPolicyRows)
                 {
-                    if (passwordPolicyRow[2].ToString() != "True")
+                    if (passwordPolicyRow[1].ToString() != "True")
                             {
                                 return new ModuleResults
                                 {

--- a/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
+++ b/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
@@ -30,7 +30,7 @@ This module also checks that there is a password policy enforced to ensure users
         }
 
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("PasswordPolicy.sql");

--- a/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
+++ b/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
@@ -40,7 +40,7 @@ This module also checks that there is a password policy enforced to ensure users
                 DataRow[] passwordFormatRow = results.Select("KeyName = 'CMSPasswordFormat'");
                 DataRow[] passwordPolicyRows = results.Select("KeyName = 'CMSUsePasswordPolicy'");
 
-                if (passwordFormatRow[0][1].ToString() != "SHA2SALT")
+                if (passwordFormatRow[0][2].ToString() != "SHA2SALT")
                         {
                             return new ModuleResults
                             {
@@ -52,7 +52,7 @@ This module also checks that there is a password policy enforced to ensure users
 
                 foreach (var passwordPolicyRow in passwordPolicyRows)
                 {
-                    if (passwordPolicyRow[1].ToString() != "True")
+                    if (passwordPolicyRow[2].ToString() != "True")
                             {
                                 return new ModuleResults
                                 {

--- a/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
+++ b/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
@@ -31,7 +31,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             // Prepare result
             DataTable result = new DataTable();

--- a/KInspector.Modules/Modules/Security/SecuritySettingsModule.cs
+++ b/KInspector.Modules/Modules/Security/SecuritySettingsModule.cs
@@ -25,7 +25,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("SecuritySettingsModule.sql");

--- a/KInspector.Modules/Modules/Security/TransformationAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/TransformationAnalyzerModule.cs
@@ -33,7 +33,7 @@ namespace Kentico.KInspector.Modules
 
         #region "Fields"
 
-        private DatabaseService mDatabaseService;
+        private IDatabaseService mDatabaseService;
         private string mInstancePath;
         HashSet<string> mTransformationFullNames;
         private string mLikePageTemplateDisplayName = "%";
@@ -87,7 +87,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             List<string> report = new List<string>();
 

--- a/KInspector.Modules/Modules/Security/UsersWithEmptyPasswordsModule.cs
+++ b/KInspector.Modules/Modules/Security/UsersWithEmptyPasswordsModule.cs
@@ -23,7 +23,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("UsersWithEmptyPasswordsModule.sql");

--- a/KInspector.Modules/Modules/Security/UsersWithPlaintextPasswordsModule.cs
+++ b/KInspector.Modules/Modules/Security/UsersWithPlaintextPasswordsModule.cs
@@ -30,7 +30,7 @@ https://docs.kentico.com/display/K82/Password+encryption+in+database"
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetTableFromFile("UsersWithPlaintextPasswordsModule.sql");

--- a/KInspector.Modules/Modules/Security/VulnerabilityAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/VulnerabilityAnalyzerModule.cs
@@ -81,7 +81,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             List<string> report = new List<string>();
 

--- a/KInspector.Modules/Modules/Security/WebPartAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/WebPartAnalyzerModule.cs
@@ -14,7 +14,7 @@ namespace Kentico.KInspector.Modules
     {
         #region "Fields"
 
-        private DatabaseService mDatabaseService;
+        private IDatabaseService mDatabaseService;
         private string mLikePageTemplateDisplayName = "%";
 
         #endregion
@@ -66,7 +66,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             List<string> report = new List<string>();
 

--- a/KInspector.Modules/Modules/Setup/LicenseSetupModule.cs
+++ b/KInspector.Modules/Modules/Setup/LicenseSetupModule.cs
@@ -23,7 +23,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetDataSetFromFile("Setup/LicenseSetupModule.sql");

--- a/KInspector.Modules/Modules/Setup/SiteDomainAliasesSetupModule.cs
+++ b/KInspector.Modules/Modules/Setup/SiteDomainAliasesSetupModule.cs
@@ -21,7 +21,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetPrintsFromFile("Setup/SiteDomainAliasesSetupModule.sql");

--- a/KInspector.Modules/Modules/Setup/SitesSetupModule.cs
+++ b/KInspector.Modules/Modules/Setup/SitesSetupModule.cs
@@ -21,7 +21,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetDataSetFromFile("Setup/SitesSetupModule.sql");

--- a/KInspector.Modules/Modules/Setup/SmtpServersSetupModule.cs
+++ b/KInspector.Modules/Modules/Setup/SmtpServersSetupModule.cs
@@ -23,7 +23,7 @@ The servers are disabled by setting their server address to invalid value, so th
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetDataSetFromFile("Setup/SmtpServerSetupModule.sql");

--- a/KInspector.Modules/Modules/Setup/StagingServersSetupModule.cs
+++ b/KInspector.Modules/Modules/Setup/StagingServersSetupModule.cs
@@ -24,7 +24,7 @@ Setting the Enabled state of all servers to false would result in UI not being a
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetDataSetFromFile("Setup/StagingServerSetupModule.sql");

--- a/KInspector.Modules/Modules/Setup/WebFarmServersSetupModule.cs
+++ b/KInspector.Modules/Modules/Setup/WebFarmServersSetupModule.cs
@@ -23,7 +23,7 @@ The servers are disabled by setting their Enabled state to disabled and their di
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             var dbService = instanceInfo.DBService;
             var results = dbService.ExecuteAndGetDataSetFromFile("Setup/WebFarmServerSetupModule.sql");

--- a/KInspector.Modules/Modules/SocialMarketing/ExpiredTokensModule.cs
+++ b/KInspector.Modules/Modules/SocialMarketing/ExpiredTokensModule.cs
@@ -22,7 +22,7 @@ namespace Kentico.KInspector.Modules
             };
         }
 
-        public ModuleResults GetResults(InstanceInfo instanceInfo)
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
         {
             DataTable expiredTokens = new DataTable("Expired account tokens");
             expiredTokens.Columns.Add("SocialNetwork");

--- a/KInspector.Modules/Scripts/PasswordPolicy.sql
+++ b/KInspector.Modules/Scripts/PasswordPolicy.sql
@@ -1,11 +1,1 @@
-﻿-- In the case of "CSMUsePasswordPolicy", the setting is given per site name. For that reason
--- the data has to be retrieved for each site so that the PasswordPolicy module can evaluate
--- said value at the 'site' level.
-SELECT 
-	ISNULL(CMS_Site.SiteDisplayName,'N/A') as SiteDisplayName, 
-	CMS_SettingsKey.KeyName, 
-	CMS_SettingsKey.KeyValue
-FROM CMS_SettingsKey 
-LEFT OUTER JOIN CMS_Site ON CMS_SettingsKey.SiteID = CMS_Site.SiteID
-WHERE 
-	(CMS_SettingsKey.KeyName IN ('CMSUsePasswordPolicy', 'CMSPasswordFormat'))
+﻿SELECT KeyName,KeyValue FROM CMS_SettingsKey WHERE KeyName IN ('CMSUsePasswordPolicy','CMSPasswordFormat');

--- a/KInspector.Modules/Scripts/PasswordPolicy.sql
+++ b/KInspector.Modules/Scripts/PasswordPolicy.sql
@@ -1,1 +1,11 @@
-﻿SELECT KeyName,KeyValue FROM CMS_SettingsKey WHERE KeyName IN ('CMSUsePasswordPolicy','CMSPasswordFormat');
+﻿-- In the case of "CSMUsePasswordPolicy", the setting is given per site name. For that reason
+-- the data has to be retrieved for each site so that the PasswordPolicy module can evaluate
+-- said value at the 'site' level.
+SELECT 
+	ISNULL(CMS_Site.SiteDisplayName,'N/A') as SiteDisplayName, 
+	CMS_SettingsKey.KeyName, 
+	CMS_SettingsKey.KeyValue
+FROM CMS_SettingsKey 
+LEFT OUTER JOIN CMS_Site ON CMS_SettingsKey.SiteID = CMS_Site.SiteID
+WHERE 
+	(CMS_SettingsKey.KeyName IN ('CMSUsePasswordPolicy', 'CMSPasswordFormat'))

--- a/KInspector.Tests/Kentico.KInspector.Tests.csproj
+++ b/KInspector.Tests/Kentico.KInspector.Tests.csproj
@@ -45,11 +45,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -61,6 +68,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="InstanceInfoTests.cs" />
+    <Compile Include="Modules\Security\PasswordPolicyModuleTests.cs" />
     <Compile Include="UIElementsDiffTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/KInspector.Tests/Modules/Security/PasswordPolicyModuleTests.cs
+++ b/KInspector.Tests/Modules/Security/PasswordPolicyModuleTests.cs
@@ -1,0 +1,230 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Kentico.KInspector.Modules;
+using System.Collections.Generic;
+using System.Linq;
+using Kentico.KInspector.Core;
+using Moq;
+using System.Data;
+
+namespace Kentico.KInspector.Tests.ModuleTests.Security
+{
+    [TestClass]
+    public class PasswordPolicyModuleTests
+    {
+        [TestMethod]
+        public void Should_BeInSecurityCategory_When_ReturningModuleMetadata()
+        {
+            // arrange...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var meta = mod.GetModuleMetadata();
+
+            // assert...
+            Assert.IsTrue(meta.Category.Equals("Security"));
+        }
+
+        [TestMethod]
+        public void Should_HaveCorrectSupportedVersions_When_ReturningModuleMetadata()
+        {
+            // arrange...
+            List<Version> expectedVersions = new List<Version>() { new Version("7.0"), new Version("8.0"), new Version("8.1"), new Version("8.2"), new Version("9.0") };
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var meta = mod.GetModuleMetadata();
+
+            // assert...
+            Assert.IsTrue((meta.SupportedVersions.Except(expectedVersions).ToList()).Count.Equals(0));
+        }
+
+        [TestMethod]
+        public void Should_PopulatedName_When_ReturningModuleMetadata()
+        {
+            // arrange...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var meta = mod.GetModuleMetadata();
+
+            // assert...
+            Assert.IsFalse(string.IsNullOrEmpty(meta.Name));
+        }
+
+        [TestMethod]
+        public void Should_PopulateComments_When_ReturningModuleMetadata()
+        {
+            // arrange...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var meta = mod.GetModuleMetadata();
+
+            // assert...
+            Assert.IsFalse(string.IsNullOrEmpty(meta.Comment));
+        }
+
+        [TestMethod]
+        public void Should_HaveStatusGood_When_PasswordPolicyDataIsGood()
+        {
+            // arrange...
+            // Mocks...
+            var mockDbs = Mock.Of<IDatabaseService>();
+            Mock.Get(mockDbs).Setup(_ => _.ExecuteAndGetTableFromFile(It.IsAny<string>())).Returns(this.MakeDataTableOK());
+            var mockInstanceInfo = new Mock<IInstanceInfo>(MockBehavior.Strict);
+            mockInstanceInfo.Setup(_ => _.DBService).Returns(mockDbs);
+
+            // Real Module under test...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var result = mod.GetResults(mockInstanceInfo.Object);
+
+            // assert...
+            StringAssert.Equals(result.ResultComment, "Password settings look good.");
+            Assert.AreEqual(Status.Good, result.Status);
+            mockInstanceInfo.VerifyAll();
+            Mock.Get(mockDbs).VerifyAll();
+        }
+
+        [TestMethod]
+        public void Should_HaveStatusError_When_PasswordFormatIsNotCorrect()
+        {
+            // arrange...
+            // Mocks...
+            var mockDbs = Mock.Of<IDatabaseService>();
+            Mock.Get(mockDbs).Setup(_ => _.ExecuteAndGetTableFromFile(It.IsAny<string>())).Returns(this.MakeDataTableWithBadPasswordFormat());
+            var mockInstanceInfo = new Mock<IInstanceInfo>(MockBehavior.Strict);
+            mockInstanceInfo.Setup(_ => _.DBService).Returns(mockDbs);
+
+            // Real Module under test...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var result = mod.GetResults(mockInstanceInfo.Object);
+
+            // assert...
+            StringAssert.Equals(result.ResultComment, "The CMSPasswordFormat should be set to 'SHA2SALT'.");
+            Assert.AreEqual(Status.Error, result.Status);
+            mockInstanceInfo.VerifyAll();
+            Mock.Get(mockDbs).VerifyAll();
+        }
+
+        [TestMethod]
+        public void Should_HaveStatusError_When_NoRecordsAreRetrieved()
+        {
+            // arrange...
+            // Mocks...
+            var mockDbs = Mock.Of<IDatabaseService>();
+            Mock.Get(mockDbs).Setup(_ => _.ExecuteAndGetTableFromFile(It.IsAny<string>())).Returns(this.MakeEmptyTable());
+            var mockInstanceInfo = new Mock<IInstanceInfo>(MockBehavior.Strict);
+            mockInstanceInfo.Setup(_ => _.DBService).Returns(mockDbs);
+
+            // Real Module under test...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var result = mod.GetResults(mockInstanceInfo.Object);
+
+            // assert...
+            StringAssert.Equals(result.ResultComment, "Failed to check settings as expected.");
+            Assert.AreEqual(Status.Error, result.Status);
+            mockInstanceInfo.VerifyAll();
+            Mock.Get(mockDbs).VerifyAll();
+        }
+
+        [TestMethod]
+        public void Should_HaveStatusWarning_When_PasswordPolicyIsFalseForAnySite()
+        {
+            // arrange...
+            // Mocks...
+            var mockDbs = Mock.Of<IDatabaseService>();
+            Mock.Get(mockDbs).Setup(_ => _.ExecuteAndGetTableFromFile(It.IsAny<string>())).Returns(this.MakeDataTableWithBadPasswordPolicy());
+            var mockInstanceInfo = new Mock<IInstanceInfo>(MockBehavior.Strict);
+            mockInstanceInfo.Setup(_ => _.DBService).Returns(mockDbs);
+
+            // Real Module under test...
+            PasswordPolicyModule mod = new PasswordPolicyModule();
+
+            // act...
+            var result = mod.GetResults(mockInstanceInfo.Object);
+
+            // assert...
+            StringAssert.Equals(result.ResultComment, "It is recommended that you have CMSUsePasswordPolicy set to 'True'.");
+            Assert.AreEqual(Status.Warning, result.Status);
+            mockInstanceInfo.VerifyAll();
+            Mock.Get(mockDbs).VerifyAll();
+        }
+
+        private DataTable MakeDataTableOK()
+        {
+            DataTable tbl = this.MakeEmptyTable();
+            DataRow newRow = tbl.NewRow();
+            // add a row for password format
+            newRow["KeyName"] = "CMSPasswordFormat";
+            newRow["KeyValue"] = "SHA2SALT";
+            tbl.Rows.Add(newRow);
+            // add a row for password policy
+            newRow = tbl.NewRow();
+            newRow["KeyName"] = "CMSUsePasswordPolicy";
+            newRow["KeyValue"] = "True";
+            tbl.Rows.Add(newRow);
+            // return the table
+            return tbl;
+        }
+
+        private DataTable MakeDataTableWithBadPasswordFormat()
+        {
+            DataTable tbl = this.MakeEmptyTable();
+            DataRow newRow = tbl.NewRow();
+            // add a row for password format
+            newRow["KeyName"] = "CMSPasswordFormat";
+            newRow["KeyValue"] = "BAD FORMAT";
+            tbl.Rows.Add(newRow);
+            // add a row for password policy
+            newRow = tbl.NewRow();
+            newRow["KeyName"] = "CMSUsePasswordPolicy";
+            newRow["KeyValue"] = "True";
+            tbl.Rows.Add(newRow);
+            // return the table
+            return tbl;
+        }
+
+        private DataTable MakeDataTableWithBadPasswordPolicy()
+        {
+            DataTable tbl = this.MakeEmptyTable();
+            DataRow newRow = tbl.NewRow();
+            // add a row for password format
+            newRow["KeyName"] = "CMSPasswordFormat";
+            newRow["KeyValue"] = "SHA2SALT";
+            tbl.Rows.Add(newRow);
+            // add a row for password policy
+            newRow = tbl.NewRow();
+            newRow["KeyName"] = "CMSUsePasswordPolicy";
+            newRow["KeyValue"] = "False";
+            tbl.Rows.Add(newRow);
+            // return the table
+            return tbl;
+        }
+
+        private DataTable MakeEmptyTable()
+        {
+            DataTable tbl = new DataTable();
+            DataColumn columnSpec = null;
+            columnSpec = new DataColumn
+            {
+                DataType = typeof(string),
+                ColumnName = "KeyName"
+            };
+            tbl.Columns.Add(columnSpec);
+            columnSpec = new DataColumn
+            {
+                DataType = typeof(string),
+                ColumnName = "KeyValue"
+            };
+            tbl.Columns.Add(columnSpec);
+            return tbl;
+        }
+    }
+}

--- a/KInspector.Tests/packages.config
+++ b/KInspector.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Preparing the way for Unit Testing of Modules by adding interfaces for DatabaseService and InstanceInfo.

This will enable the use of mocks to more effectively Unit Test any module classes without needing a fully operational instance of Kentico to test module behavior.