### PR TITLE
PasswordPolicyModule changes to Fix #17 

### DIFF
--- a/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
+++ b/KInspector.Modules/Modules/Security/PasswordPolicyModule.cs
@@ -3,6 +3,7 @@ using System.Configuration;
 using System.Data;
 using System.IO;
 using System.Web;
+using System.Linq;
 using System.Web.Configuration;
 using Kentico.KInspector.Core;
 
@@ -16,7 +17,6 @@ namespace Kentico.KInspector.Modules
             {
                 Name = "Password policy settings",
                 Comment = @"It is critical that passwords are stored securely in the database, the module checks that the default and recommended SHA2 option is configured. https://docs.kentico.com/display/K9/Password+encryption+in+database
-
 This module also checks that there is a password policy enforced to ensure users use a password that meets a minimum set of requirements. https://docs.kentico.com/display/K9/Password+strength+policy+and+its+enforcement",
                 SupportedVersions = new[] {
                     new Version("7.0"),
@@ -36,29 +36,29 @@ This module also checks that there is a password policy enforced to ensure users
             var results = dbService.ExecuteAndGetTableFromFile("PasswordPolicy.sql");
 
             if (results.Rows.Count > 0)
-            { 
-                DataRow[] passwordFormatRow = results.Select("KeyName = 'CMSPasswordFormat'");
-                DataRow[] passwordPolicyRow = results.Select("KeyName = 'CMSUsePasswordPolicy'");
+            {
+                DataRow[] passwordFormatRows = results.Select("KeyName = 'CMSPasswordFormat'");
+                DataRow[] passwordPolicyRows = results.Select("KeyName = 'CMSUsePasswordPolicy'");
 
-                if (passwordFormatRow[0][1].ToString() != "SHA2SALT")
-                {
-                    return new ModuleResults
-                    {
-                        Result = results,
-                        ResultComment = "The CMSPasswordFormat should be set to 'SHA2SALT'.",
-                        Status = Status.Error,
-                    };
-                }
-                else if (passwordPolicyRow[0][1].ToString() != "True")
-                {
-                    return new ModuleResults
-                    {
-                        Result = results,
-                        ResultComment = "It is recommended that you have CMSUsePasswordPolicy set to 'True'.",
-                        Status = Status.Warning,
-                    };
-                }
-                else
+                if (passwordFormatRows.Any(r => r["KeyValue"].ToString() != "SHA2SALT"))
+                        {
+                            return new ModuleResults
+                            {
+                                Result = results,
+                                ResultComment = "The CMSPasswordFormat should be set to 'SHA2SALT'.",
+                                Status = Status.Error,
+                            };
+                        } 
+                else if(passwordPolicyRows.Any(r => r["KeyValue"].ToString() != "True"))
+                            {
+                                return new ModuleResults
+                                {
+                                    Result = results,
+                                    ResultComment = "It is recommended that you have CMSUsePasswordPolicy set to 'True'.",
+                                    Status = Status.Warning,
+                                };
+                            }
+                else 
                 {
                     return new ModuleResults
                     {

--- a/KInspector.Modules/Scripts/PasswordPolicy.sql
+++ b/KInspector.Modules/Scripts/PasswordPolicy.sql
@@ -1,1 +1,11 @@
-﻿SELECT KeyName,KeyValue FROM CMS_SettingsKey WHERE KeyName IN ('CMSUsePasswordPolicy','CMSPasswordFormat');
+﻿-- In the case of "CSMUsePasswordPolicy", the setting is given per site name. For that reason
+-- the data has to be retrieved for each site so that the PasswordPolicy module can evaluate
+-- said value at the 'site' level.
+SELECT 
+	ISNULL(CMS_Site.SiteDisplayName,'N/A') as SiteDisplayName, 
+	CMS_SettingsKey.KeyName, 
+	CMS_SettingsKey.KeyValue
+FROM CMS_SettingsKey 
+LEFT OUTER JOIN CMS_Site ON CMS_SettingsKey.SiteID = CMS_Site.SiteID
+WHERE 
+	(CMS_SettingsKey.KeyName IN ('CMSUsePasswordPolicy', 'CMSPasswordFormat')) 


### PR DESCRIPTION
Made modifications to PasswordPolicyModule and PasswordPolicy DB script to account for multiple sites.

This fix also accounts for the access to DataTable elements by "ColumnName" rather than by index, [x].

Finally, corresponding unit tests for the PasswordPolicyModule were reviewed (optimized) somewhat.