### PR TITLE
Fixes #84. Upgrading to .NET 4.6.1 and making use of C#6 Language Features

### DIFF
--- a/KInspector.Core/InstanceInfo.cs
+++ b/KInspector.Core/InstanceInfo.cs
@@ -14,38 +14,17 @@ namespace Kentico.KInspector.Core
         /// <summary>
         /// URI of the application instance
         /// </summary>
-        public Uri Uri
-        {
-            get
-            {
-                return uri.Value;
-            }
-        }
-
+        public Uri Uri => uri.Value;
 
         /// <summary>
         /// Directory of the application instance
         /// </summary>
-        public DirectoryInfo Directory
-        {
-            get
-            {
-                return directory.Value;
-            }
-        }
-
+        public DirectoryInfo Directory => directory.Value;
 
         /// <summary>
         /// Version of the instance based on the database setting key.
         /// </summary>
-        public Version Version
-        {
-            get
-            {
-                return version.Value;
-            }
-        }
-
+        public Version Version => version.Value;
 
         /// <summary>
         /// Configuration with instance information.
@@ -56,14 +35,7 @@ namespace Kentico.KInspector.Core
         /// <summary>
         /// Database service to communicate with the instance database.
         /// </summary>
-        public IDatabaseService DBService
-        {
-            get
-            {
-                return dbService.Value;
-            }
-        }
-
+        public IDatabaseService DBService => dbService.Value;
 
         /// <summary>
         /// Creates instance information based on configuration.

--- a/KInspector.Core/Kentico.KInspector.Core.csproj
+++ b/KInspector.Core/Kentico.KInspector.Core.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Kentico.KInspector.Core</RootNamespace>
     <AssemblyName>Kentico.KInspector.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -21,6 +21,7 @@
     </SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\KInspector\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/KInspector.Modules/Helpers/ProbeHelper.cs
+++ b/KInspector.Modules/Helpers/ProbeHelper.cs
@@ -35,14 +35,7 @@ namespace Kentico.KInspector.Modules
         /// <summary>
         /// Gets enumeration of probe files as an enumeration of relative paths.
         /// </summary>
-        private static IEnumerable<string> ProbeFilesRelativePath
-        {
-            get
-            {
-                return Directory.EnumerateFiles(PROBE_DATA_FOLDER_PATH, "*", SearchOption.AllDirectories);
-            }
-        }
-
+        private static IEnumerable<string> ProbeFilesRelativePath => Directory.EnumerateFiles(PROBE_DATA_FOLDER_PATH, "*", SearchOption.AllDirectories);
 
         /// <summary>
         /// Installs the probe for Kentico instance residing in <paramref name="pathToKenticoFiles"/>

--- a/KInspector.Modules/Helpers/ProjectCodeFilesHelper.cs
+++ b/KInspector.Modules/Helpers/ProjectCodeFilesHelper.cs
@@ -93,7 +93,7 @@ namespace Kentico.KInspector.Modules
             catch (FileNotFoundException ex)
             {
                 // Thrown when metafile for given version is not available
-                throw new ArgumentException(string.Format("Default project code files listing for version {0} is not supported.", version.ToString(2)), ex);
+                throw new ArgumentException($"Default project code files listing for version {version.ToString(2)} is not supported.", ex);
             }
         }
 
@@ -126,7 +126,7 @@ namespace Kentico.KInspector.Modules
         /// <returns></returns>
         private string GetMetaFilePath(Version version, bool isWebSiteProject)
         {
-            string metaFileName = string.Format("K{0}{1}web{2}.txt", version.Major, version.Minor > 0 ? version.Minor.ToString() : string.Empty, isWebSiteProject ? "site" : "app");
+            string metaFileName = $"K{version.Major}{(version.Minor > 0 ? version.Minor.ToString() : string.Empty)}web{(isWebSiteProject ? "site" : "app")}.txt";
             
             return Path.Combine(DEFAULT_INSTALLATION_FILES_DIR_PATH, metaFileName);
         }

--- a/KInspector.Modules/Kentico.KInspector.Modules.csproj
+++ b/KInspector.Modules/Kentico.KInspector.Modules.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Kentico.KInspector.Modules</RootNamespace>
     <AssemblyName>Kentico.KInspector.Modules</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -21,6 +21,7 @@
     </SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/KInspector.Modules/Modules/Content/SiteTemplatesModule.cs
+++ b/KInspector.Modules/Modules/Content/SiteTemplatesModule.cs
@@ -143,7 +143,7 @@ namespace Kentico.KInspector.Modules
 
                 var documents = dbService.ExecuteAndGetTableFromFile("SiteTemplatesModule-Documents.sql", 
                     new SqlParameter("PageTemplateID", template["PageTemplateID"]));
-                documents.TableName = string.Format("{0} - Documents", templateName);
+                documents.TableName = $"{templateName} - Documents";
                 results.Tables.Add(documents.Copy());
             }
 

--- a/KInspector.Modules/Modules/Content/WorkflowConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/WorkflowConsistencyModule.cs
@@ -199,7 +199,7 @@ Implication of such inconsistency is that when you look at a document in Content
             var dict = new Dictionary<string, object>();
 
             // Get all columns from coupled table
-            var sql = string.Format("select * from {0} where {1} = '{2}'", classItem.TableName, classItem.PrimaryKeyName, documentForeignKeyValue);
+            var sql = $"select * from {classItem.TableName} where {classItem.PrimaryKeyName} = '{documentForeignKeyValue}'";
 
             var result = InstanceInfo.DBService.ExecuteAndGetDataSet(sql);
 

--- a/KInspector.Modules/Modules/Content/WorkflowConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/WorkflowConsistencyModule.cs
@@ -277,13 +277,7 @@ Implication of such inconsistency is that when you look at a document in Content
             public string DocumentCulture { get; private set; }
             public string NodeAliasPath { get; private set; }
 
-            public string NotMachingFieldsString
-            {
-                get
-                {
-                    return string.Join(";", NotMatchingFields);
-                }
-            }
+            public string NotMachingFieldsString => string.Join(";", NotMatchingFields);
 
             public ResultItem(int documentID, List<string> notMatchingFields, string documentCulture, string nodeAliasPath)
             {
@@ -310,13 +304,7 @@ Implication of such inconsistency is that when you look at a document in Content
             public string ClassName { get; set; }
             public string TableName { get; set; }
             public string ClassFormDefinition { get; set; }
-            public string PrimaryKeyName
-            {
-                get
-                {
-                    return GetPrimaryKeyName();
-                }
-            }
+            public string PrimaryKeyName => GetPrimaryKeyName();
 
             private string GetPrimaryKeyName()
             {

--- a/KInspector.Modules/Modules/General/BigTablesModule.cs
+++ b/KInspector.Modules/Modules/General/BigTablesModule.cs
@@ -33,8 +33,7 @@ namespace Kentico.KInspector.Modules
             return new ModuleResults
             {
                 Result = results,
-                ResultComment = string.Format("The overall database size is {0} MB", databaseSizeInMB)
-            };
+                ResultComment = $"The overall database size is {databaseSizeInMB} MB"};
         }
     }
 }

--- a/KInspector.Modules/Modules/General/PagesAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/General/PagesAnalyzerModule.cs
@@ -228,11 +228,11 @@ OR '{0}' LIKE '%' + sa.SiteDomainAliasName + '%') AND s.SiteStatus = N'RUNNING'"
                     bool faviconAvailable = ProbeUri(faviconUri);
                     if (faviconAvailable)
                     {
-                        faviconAvailabilityCache[faviconUri.AbsoluteUri] = (defaultFavicon) ? "OK (Default)\n" : string.Format("OK ('{0}')\n", faviconHref);
+                        faviconAvailabilityCache[faviconUri.AbsoluteUri] = (defaultFavicon) ? "OK (Default)\n" : $"OK ('{faviconHref}')\n";
                     }
                     else
                     {
-                        faviconAvailabilityCache[faviconUri.AbsoluteUri] = (defaultFavicon) ? "NOT SPECIFIED\n" : string.Format("MISSING ('{0}')\n", faviconHref);
+                        faviconAvailabilityCache[faviconUri.AbsoluteUri] = (defaultFavicon) ? "NOT SPECIFIED\n" : $"MISSING ('{faviconHref}')\n";
                     }
                     res.Append(faviconAvailabilityCache[faviconUri.AbsoluteUri]);
                 }
@@ -273,11 +273,11 @@ OR '{0}' LIKE '%' + sa.SiteDomainAliasName + '%') AND s.SiteStatus = N'RUNNING'"
                         bool faviconAvailable = ProbeUri(iconUri);
                         if (faviconAvailable)
                         {
-                            touchIconAvailabilityCache[iconUri.AbsoluteUri] = string.Format("OK ('{0}')\n", iconHref);
+                            touchIconAvailabilityCache[iconUri.AbsoluteUri] = $"OK ('{iconHref}')\n";
                         }
                         else
                         {
-                            touchIconAvailabilityCache[iconUri.AbsoluteUri] = string.Format("MISSING ('{0}')\n", iconHref);
+                            touchIconAvailabilityCache[iconUri.AbsoluteUri] = $"MISSING ('{iconHref}')\n";
                         }
                         res.Append(touchIconAvailabilityCache[iconUri.AbsoluteUri]);
                     }
@@ -330,8 +330,7 @@ OR '{0}' LIKE '%' + sa.SiteDomainAliasName + '%') AND s.SiteStatus = N'RUNNING'"
                 return result;
             }
 
-            throw new InvalidOperationException(string.Format("[PagesAnalyzerModule.GetUri]: The base URI '{0}' and href '{1}' do not produce a valid URI.",
-                baseUri, href));
+            throw new InvalidOperationException($"[PagesAnalyzerModule.GetUri]: The base URI '{baseUri}' and href '{href}' do not produce a valid URI.");
         }
 
 

--- a/KInspector.Modules/Modules/General/ScreenshotterModule.cs
+++ b/KInspector.Modules/Modules/General/ScreenshotterModule.cs
@@ -154,13 +154,13 @@ NOTE: Current implementation will only take screenshots of the site you've enter
 
         private static void Log(string message)
         {
-            Console.WriteLine("[{0}]: {1}", DateTime.Now, message);
+            Console.WriteLine($"[{DateTime.Now}]: {message}");
         }
 
 
         private static void Log(string message, params object[] args)
         {
-            Console.WriteLine("[{0}]: {1}", DateTime.Now, string.Format(message, args));
+            Console.WriteLine($"[{DateTime.Now}]: {string.Format(message, args)}");
         }
 
 

--- a/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
+++ b/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
@@ -183,7 +183,7 @@ namespace Kentico.KInspector.Modules
         {
             if (!Directory.Exists(path))
             {
-                validationErrorMessage = string.Format("The given path '{0}' to Kentico instance is not valid. Maybe it is not accessible by the tool.", path);
+                validationErrorMessage = $"The given path '{path}' to Kentico instance is not valid. Maybe it is not accessible by the tool.";
 
                 return false;
             }

--- a/KInspector.Modules/Modules/Security/TransformationAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/TransformationAnalyzerModule.cs
@@ -36,8 +36,6 @@ namespace Kentico.KInspector.Modules
         private IDatabaseService mDatabaseService;
         private string mInstancePath;
         HashSet<string> mTransformationFullNames;
-        private string mLikePageTemplateDisplayName = "%";
-
         #endregion
 
 
@@ -53,18 +51,7 @@ namespace Kentico.KInspector.Modules
         /// This should be improved to be able to set the value of this property
         /// based on what the user wants.
         /// </remarks>
-        public string LikePageTemplateDisplayName
-        {
-            get
-            {
-                return mLikePageTemplateDisplayName;
-            }
-            set
-            {
-                mLikePageTemplateDisplayName = value;
-            }
-        }
-
+        public string LikePageTemplateDisplayName { get; set; } = "%";
         #endregion
 
 

--- a/KInspector.Modules/Modules/Security/VulnerabilityAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/VulnerabilityAnalyzerModule.cs
@@ -157,15 +157,15 @@ namespace Kentico.KInspector.Modules
 
                 if (!string.IsNullOrEmpty(sqlInjection))
                 {
-                    results.SqlInjections.Add(string.Format("File: '{0}', line {1}: {2}", fileWithinInstance, lineNo, HttpUtility.HtmlEncode(sqlInjection)));
+                    results.SqlInjections.Add($"File: '{fileWithinInstance}', line {lineNo}: {HttpUtility.HtmlEncode(sqlInjection)}");
                 }
                 if (!string.IsNullOrEmpty(potentialSqlInjection))
                 {
-                    results.PotentialSqlInjections.Add(string.Format("File: '{0}', line {1}: {2}", fileWithinInstance, lineNo, HttpUtility.HtmlEncode(potentialSqlInjection)));
+                    results.PotentialSqlInjections.Add($"File: '{fileWithinInstance}', line {lineNo}: {HttpUtility.HtmlEncode(potentialSqlInjection)}");
                 }
                 if (!string.IsNullOrEmpty(potentialXss))
                 {
-                    results.PotentialXss.Add(string.Format("File: '{0}', line {1}: {2}", fileWithinInstance, lineNo, HttpUtility.HtmlEncode(potentialXss)));
+                    results.PotentialXss.Add($"File: '{fileWithinInstance}', line {lineNo}: {HttpUtility.HtmlEncode(potentialXss)}");
                 }
 
                 ++lineNo;
@@ -323,7 +323,7 @@ namespace Kentico.KInspector.Modules
             {
                 foreach (Match match in pattern.Matches(result))
                 {
-                    result = result.Replace(match.Value, string.Format("<span style=\"color: red;\">{0}</span>", match.Value));
+                    result = result.Replace(match.Value, $"<span style=\"color: red;\">{match.Value}</span>");
                 }
             }
 

--- a/KInspector.Modules/Modules/Security/WebPartAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/WebPartAnalyzerModule.cs
@@ -15,8 +15,6 @@ namespace Kentico.KInspector.Modules
         #region "Fields"
 
         private IDatabaseService mDatabaseService;
-        private string mLikePageTemplateDisplayName = "%";
-
         #endregion
 
 
@@ -32,18 +30,7 @@ namespace Kentico.KInspector.Modules
         /// This should be improved to be able to set the value of this property
         /// based on what the user wants.
         /// </remarks>
-        public string LikePageTemplateDisplayName
-        {
-            get
-            {
-                return mLikePageTemplateDisplayName;
-            }
-            set
-            {
-                mLikePageTemplateDisplayName = value;
-            }
-        }
-
+        public string LikePageTemplateDisplayName { get; set; } = "%";
         #endregion
 
 

--- a/KInspector.Modules/Modules/Security/WebPartAnalyzerModule.cs
+++ b/KInspector.Modules/Modules/Security/WebPartAnalyzerModule.cs
@@ -184,11 +184,8 @@ namespace Kentico.KInspector.Modules
                         bool containsMacros = MacroValidator.Current.ContainsMacros(innerText, macroTypes);
                         if (containsMacros)
                         {
-                            string report = string.Format("Web part: {0}/{1}, property: {2} <br /> <strong>{3}</strong>.<br />",
-                                    webPartNode.Attributes["controlid"].Value,
-                                    webPartNode.Attributes["type"].Value,
-                                    nameAttribute.Value,
-                                    MacroValidator.Current.HighlightMacros(HttpUtility.HtmlEncode(innerText), macroTypes));
+                            string report =
+                                $"Web part: {webPartNode.Attributes["controlid"].Value}/{webPartNode.Attributes["type"].Value}, property: {nameAttribute.Value} <br /> <strong>{MacroValidator.Current.HighlightMacros(HttpUtility.HtmlEncode(innerText), macroTypes)}</strong>.<br />";
 
                             res.Add(report);
                         }

--- a/KInspector.Tests/Kentico.KInspector.Tests.csproj
+++ b/KInspector.Tests/Kentico.KInspector.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Kentico.KInspector.Tests</RootNamespace>
     <AssemblyName>Kentico.KInspector.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -26,6 +26,7 @@
     </SccProvider>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/KInspector.Tests/Modules/Security/PasswordPolicyModuleTests.cs
+++ b/KInspector.Tests/Modules/Security/PasswordPolicyModuleTests.cs
@@ -177,7 +177,7 @@ namespace Kentico.KInspector.Tests.ModuleTests.Security
             {
                 // add a row for password policy
                 newRow = tbl.NewRow();
-                newRow["SiteDisplayName"] = string.Format("Good Site Name {0}", i);
+                newRow["SiteDisplayName"] = $"Good Site Name {i}";
                 newRow["KeyName"] = "CMSUsePasswordPolicy";
                 newRow["KeyValue"] = "True";
                 tbl.Rows.Add(newRow);                
@@ -186,7 +186,7 @@ namespace Kentico.KInspector.Tests.ModuleTests.Security
             {
                 // add a row for password policy
                 newRow = tbl.NewRow();
-                newRow["SiteDisplayName"] = string.Format("Bad Site Name {0}", j);
+                newRow["SiteDisplayName"] = $"Bad Site Name {j}";
                 newRow["KeyName"] = "CMSUsePasswordPolicy";
                 newRow["KeyValue"] = "False";
                 tbl.Rows.Add(newRow);                

--- a/KInspector.Web/App.config
+++ b/KInspector.Web/App.config
@@ -1,30 +1,30 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
     </startup>
   <runtime>
-    <loadFromRemoteSources enabled="true" />
+    <loadFromRemoteSources enabled="true"/>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <assemblyIdentity name="System.Web.Cors" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/KInspector.Web/Kentico.KInspector.Web.csproj
+++ b/KInspector.Web/Kentico.KInspector.Web.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Kentico.KInspector.Web</RootNamespace>
     <AssemblyName>Kentico.KInspector.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -36,6 +36,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/KInspector.Web/WebAPI/Controllers/ModulesController.cs
+++ b/KInspector.Web/WebAPI/Controllers/ModulesController.cs
@@ -45,8 +45,7 @@ namespace Kentico.KInspector.Web
 
 				if (!modules.Any())
 				{
-					return Request.CreateResponse(HttpStatusCode.BadRequest,
-						string.Format("There are no modules available for version {0}.", version));
+					return Request.CreateResponse(HttpStatusCode.BadRequest, $"There are no modules available for version {version}.");
 				}
 
 				return Request.CreateResponse(HttpStatusCode.OK, modules);
@@ -75,8 +74,7 @@ namespace Kentico.KInspector.Web
 
 				if (!modules.Any())
 				{
-					return Request.CreateResponse(HttpStatusCode.BadRequest,
-						string.Format("There are no modules available for version {0}.", version));
+					return Request.CreateResponse(HttpStatusCode.BadRequest, $"There are no modules available for version {version}.");
 				}
 
 				return Request.CreateResponse(HttpStatusCode.OK, modules);
@@ -101,8 +99,7 @@ namespace Kentico.KInspector.Web
 			}
 			catch (Exception e)
 			{
-				return Request.CreateResponse(HttpStatusCode.InternalServerError,
-					string.Format("Error in \"{0}\" module. Error message: {1}", moduleName, e.Message));
+				return Request.CreateResponse(HttpStatusCode.InternalServerError, $"Error in \"{moduleName}\" module. Error message: {e.Message}");
 			}
 		}
 


### PR DESCRIPTION
Upgraded all projects to .NET 4.6.1 and making use of the following C#6 Language Features:

- String Interpolation
- Auto Properties
- Expression Body Member