### PR TITLE
Display module description separately from running the module

### DIFF
--- a/KInspector.Web/FrontEnd/Scripts/Directives.js
+++ b/KInspector.Web/FrontEnd/Scripts/Directives.js
@@ -26,6 +26,11 @@
                         }
                     }
 
+                    $scope.commentsVisible = false;
+                    $scope.toggleCommentsVisibility = function (e) {
+                    	$scope.commentsVisible = !$scope.commentsVisible;
+                    }
+
                     $scope.$watchCollection('model.results', function (newResults) {
                         if (newResults) {
                             $scope.model.resultClass = 'result-status-' + newResults.Status;
@@ -97,7 +102,7 @@
                                     }
                                 })
                                 .finally(function () {
-                                    $scope.model.moduleLoading = false;
+                                	$scope.model.moduleLoading = false;
                                 });
 		                }
 		            };

--- a/KInspector.Web/FrontEnd/index.html
+++ b/KInspector.Web/FrontEnd/index.html
@@ -222,7 +222,7 @@
 						<li ng-show="!model.moduleLoaded && !model.moduleLoading" class="active" ng-click="loadModule(false, true)"><a href="javascript:void(0);">Load the module</a></li>
 						<li ng-show="model.moduleLoading"><div style="padding-top: 0.5rem;"><knl-loader /></div></li>
 						<li ng-show="model.moduleLoaded"><a class="reload-link" href="javascript:void(0);" ng-click="loadModule(true, true)">↺</a></li>
-						<li ng-show="model.moduleLoaded" ng-click="toggleResultsVisibility()"><div style="padding-left: 1rem; padding-top: 1rem; padding-right: 1rem;"><div ng-class="{'arrow-down': !resultsVisible, 'arrow-up': resultsVisible}"></div></div></li>
+						<li ng-show="model.moduleLoaded"><div style="padding-left: 1rem; padding-top: 1rem; padding-right: 1rem;"><div ng-class="{'arrow-down': !resultsVisible, 'arrow-up': resultsVisible}"></div></div></li>
 					</ul>
 				</section>
 			</nav>

--- a/KInspector.Web/FrontEnd/index.html
+++ b/KInspector.Web/FrontEnd/index.html
@@ -217,8 +217,8 @@
 
                 <section class="top-bar-section">
                     <ul class="right">
-						<li ng-show="!commentsVisible" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Show Comments</a></li>
-						<li ng-show="commentsVisible" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Hide Comments</a></li>
+						<li ng-show="!commentsVisible && !model.moduleLoaded && !model.moduleLoading" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Show Comments</a></li>
+						<li ng-show="commentsVisible && !model.moduleLoaded && !model.moduleLoading" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Hide Comments</a></li>
 						<li ng-show="!model.moduleLoaded && !model.moduleLoading" class="active" ng-click="loadModule(false, true)"><a href="javascript:void(0);">Load the module</a></li>
                         <li ng-show="model.moduleLoading"><div style="padding-top: 0.5rem;"><knl-loader /></div></li>
                         <li ng-show="model.moduleLoaded"><a class="reload-link" href="javascript:void(0);" ng-click="loadModule(true, true)">↺</a></li>
@@ -226,10 +226,11 @@
                     </ul>
                 </section>
             </nav>
-			<div class="panel" ng-show="commentsVisible">
+			<div class="panel" ng-show="commentsVisible && !model.moduleLoaded && !model.moduleLoading">
 				<div class="panel"><pre class="module-comment-breakable">{{moduleMetaData.Comment}}</pre></div>
 			</div>
-            <div class="panel" ng-show="resultsVisible">              
+            <div class="panel" ng-show="resultsVisible">
+				<div class="panel"><pre class="module-comment-breakable">{{moduleMetaData.Comment}}</pre></div>              
                 <div ng-transclude></div>
                 <div class="results-footer" ng-show="model.results.ResultComment">{{model.results.ResultComment}}</div>
             </div>

--- a/KInspector.Web/FrontEnd/index.html
+++ b/KInspector.Web/FrontEnd/index.html
@@ -208,24 +208,24 @@
     <!-- TEMPLATE FOR THE CONTAINER OF THE MODULE - THE COLORED PANEL WITH AN ARROW POINTING DOWN/UP -->
     <script type="text/ng-template" id="partials/module-item-container.html">
         <div class="module-container">
-            <nav ng-class="{pointer: model.moduleLoaded}" class="{{model.resultClass}} top-bar" data-topbar role="navigation">
-                <ul class="title-area" ng-click="toggleResultsVisibility()">
-                    <li class="name">
-                        <h1><span class="results-module-name">[{{moduleMetaData.Category || 'General'}}] {{moduleMetaData.Name}}</span></h1>
-                    </li>
-                </ul>
+			<nav ng-class="{pointer: model.moduleLoaded}" ng-click="toggleResultsVisibility()" class="{{model.resultClass}} top-bar" data-topbar role="navigation">
+				<ul class="title-area">
+					<li class="name">
+						<h1><span class="results-module-name">[{{moduleMetaData.Category || 'General'}}] {{moduleMetaData.Name}}</span></h1>
+					</li>
+				</ul>
 
-                <section class="top-bar-section">
-                    <ul class="right">
+				<section class="top-bar-section">
+					<ul class="right">
 						<li ng-show="!commentsVisible && !model.moduleLoaded && !model.moduleLoading" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Show Comments</a></li>
 						<li ng-show="commentsVisible && !model.moduleLoaded && !model.moduleLoading" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Hide Comments</a></li>
 						<li ng-show="!model.moduleLoaded && !model.moduleLoading" class="active" ng-click="loadModule(false, true)"><a href="javascript:void(0);">Load the module</a></li>
-                        <li ng-show="model.moduleLoading"><div style="padding-top: 0.5rem;"><knl-loader /></div></li>
-                        <li ng-show="model.moduleLoaded"><a class="reload-link" href="javascript:void(0);" ng-click="loadModule(true, true)">↺</a></li>
-                        <li ng-show="model.moduleLoaded" ng-click="toggleResultsVisibility()" ><div style="padding-left: 1rem; padding-top: 1rem; padding-right: 1rem;"><div ng-class="{'arrow-down': !resultsVisible, 'arrow-up': resultsVisible}"></div></div></li>
-                    </ul>
-                </section>
-            </nav>
+						<li ng-show="model.moduleLoading"><div style="padding-top: 0.5rem;"><knl-loader /></div></li>
+						<li ng-show="model.moduleLoaded"><a class="reload-link" href="javascript:void(0);" ng-click="loadModule(true, true)">↺</a></li>
+						<li ng-show="model.moduleLoaded" ng-click="toggleResultsVisibility()"><div style="padding-left: 1rem; padding-top: 1rem; padding-right: 1rem;"><div ng-class="{'arrow-down': !resultsVisible, 'arrow-up': resultsVisible}"></div></div></li>
+					</ul>
+				</section>
+			</nav>
 			<div class="panel" ng-show="commentsVisible && !model.moduleLoaded && !model.moduleLoading">
 				<div class="panel"><pre class="module-comment-breakable">{{moduleMetaData.Comment}}</pre></div>
 			</div>

--- a/KInspector.Web/FrontEnd/index.html
+++ b/KInspector.Web/FrontEnd/index.html
@@ -208,8 +208,8 @@
     <!-- TEMPLATE FOR THE CONTAINER OF THE MODULE - THE COLORED PANEL WITH AN ARROW POINTING DOWN/UP -->
     <script type="text/ng-template" id="partials/module-item-container.html">
         <div class="module-container">
-            <nav ng-click="toggleResultsVisibility()" ng-class="{pointer: model.moduleLoaded}" class="{{model.resultClass}} top-bar" data-topbar role="navigation">
-                <ul class="title-area">
+            <nav ng-class="{pointer: model.moduleLoaded}" class="{{model.resultClass}} top-bar" data-topbar role="navigation">
+                <ul class="title-area" ng-click="toggleResultsVisibility()">
                     <li class="name">
                         <h1><span class="results-module-name">[{{moduleMetaData.Category || 'General'}}] {{moduleMetaData.Name}}</span></h1>
                     </li>
@@ -217,15 +217,19 @@
 
                 <section class="top-bar-section">
                     <ul class="right">
-                        <li ng-show="!model.moduleLoaded && !model.moduleLoading" class="active" ng-click="loadModule(false, true)"><a href="javascript:void(0);">Load the module</a></li>
+						<li ng-show="!commentsVisible" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Show Comments</a></li>
+						<li ng-show="commentsVisible" class="active" ng-click="toggleCommentsVisibility()"><a href="javascript:void(0);">Hide Comments</a></li>
+						<li ng-show="!model.moduleLoaded && !model.moduleLoading" class="active" ng-click="loadModule(false, true)"><a href="javascript:void(0);">Load the module</a></li>
                         <li ng-show="model.moduleLoading"><div style="padding-top: 0.5rem;"><knl-loader /></div></li>
                         <li ng-show="model.moduleLoaded"><a class="reload-link" href="javascript:void(0);" ng-click="loadModule(true, true)">↺</a></li>
-                        <li ng-show="model.moduleLoaded"><div style="padding-left: 1rem; padding-top: 1rem; padding-right: 1rem;"><div ng-class="{'arrow-down': !resultsVisible, 'arrow-up': resultsVisible}"></div></div></li>
+                        <li ng-show="model.moduleLoaded" ng-click="toggleResultsVisibility()" ><div style="padding-left: 1rem; padding-top: 1rem; padding-right: 1rem;"><div ng-class="{'arrow-down': !resultsVisible, 'arrow-up': resultsVisible}"></div></div></li>
                     </ul>
                 </section>
             </nav>
-            <div class="panel" ng-show="resultsVisible">
-                <div class="panel"><pre class="module-comment-breakable">{{moduleMetaData.Comment}}</pre></div>
+			<div class="panel" ng-show="commentsVisible">
+				<div class="panel"><pre class="module-comment-breakable">{{moduleMetaData.Comment}}</pre></div>
+			</div>
+            <div class="panel" ng-show="resultsVisible">              
                 <div ng-transclude></div>
                 <div class="results-footer" ng-show="model.results.ResultComment">{{model.results.ResultComment}}</div>
             </div>


### PR DESCRIPTION
…he module

Currently, in order to see the details of what a module does, you have to Load the Module, executing its behavior. This is problematic because first-time users won't have the context of what the modules do in order to know which module they want to run. This commit adds a button "Show Comments" that displays the comments separately from the results. In order to do this without also displaying the "results", I had to remove the Results toggle from the header bar, and place it directly on the Toggle arrow and the Header text. No other changes to existing functionality were needed.