### PR TITLE
Add reset to password expiration for global admin reset module

### DIFF
--- a/KInspector.Modules/Scripts/Setup/GlobalAdminSetupModule.sql
+++ b/KInspector.Modules/Scripts/Setup/GlobalAdminSetupModule.sql
@@ -1,4 +1,8 @@
 --clear the password for the admin account
- UPDATE CMS_User
- SET UserName = 'administrator', UserIsGlobalAdministrator = 1, UserPassword = '', UserEnabled = 1
- WHERE UserID = 53
+UPDATE CMS_User
+	SET UserName = 'administrator', UserIsGlobalAdministrator = 1, UserPassword = '', UserEnabled = 1
+	WHERE UserID = 53
+
+UPDATE CMS_UserSettings
+	SET UserPasswordLastChanged = GETDATE()
+	WHERE UserSettingsUserID = 53


### PR DESCRIPTION
Fixes edge-case where global admin account is immediately locked if
password expiration is enabled, account locking is set, and the global
admin last changed the password earlier than the expiration window.