### PR TITLE
Media file consistency module

### DIFF
--- a/KInspector.Modules/Kentico.KInspector.Modules.csproj
+++ b/KInspector.Modules/Kentico.KInspector.Modules.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Helpers\ProbeHelper.cs" />
     <Compile Include="Helpers\ProjectCodeFilesHelper.cs" />
     <Compile Include="Modules\Content\AttachmentsBySizeModule.cs" />
+    <Compile Include="Modules\Content\DBFileConsistencyModule.cs" />
     <Compile Include="Modules\Content\NumberOfAliasesModule.cs" />
     <Compile Include="Modules\Content\RobotsTxtModule.cs" />
     <Compile Include="Modules\Content\PageTypeAssignedToSiteModule.cs" />
@@ -202,6 +203,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Scripts\FloodProtectionModule.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Scripts\GetLibraryAndAttachmentFiles.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Scripts\PageTypeFieldsDataTypeMismatchModule.sql">

--- a/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+using Kentico.KInspector.Core;
+
+namespace Kentico.KInspector.Modules
+{
+	public class DBFileConsistencyModule: IModule
+	{
+		public ModuleMetadata GetModuleMetadata()
+		{
+			return new ModuleMetadata
+			{
+				Name = "Form Attachments and Media Library Consistency Check",
+				SupportedVersions = new[] {
+					new Version("6.0"),
+					new Version("7.0"),
+					new Version("8.0"),
+					new Version("8.1"),
+					new Version("8.2"),
+					new Version("9.0")
+				},
+				Comment =
+@"Compares the list of Attachments and Media Library items against the database, to find:
+1) Media Library records not associated with any file in the filesystem.
+2) Form Attachments files not associated with any Form record in Kentico
+3) Form Attachments records not associated with any file in the filesystem.
+
+Note: Page attachments and metafiles can be administered in System->Files: https://docs.kentico.com/display/K9/Administering+files+globally",
+				Category = "Content"
+			};
+		}
+
+		public ModuleResults GetResults(IInstanceInfo instanceInfo)
+		{
+			var dbService = instanceInfo.DBService;
+			
+			var allData = dbService.ExecuteAndGetDataSetFromFile("GetLibraryAndAttachmentFiles.sql");
+			allData.Tables[0].TableName = "KenticoSites";
+			/* [SiteID]
+			  ,[SiteName] */
+
+			allData.Tables[1].TableName = "KenticoSettings";
+			/* [CategoryName]
+			  ,[KeyName]
+			  ,[KeyValue]
+			  ,[SiteID] */
+
+			allData.Tables[2].TableName = "MediaLibraryRecords";
+			/* [FileName]
+			  ,[FileSiteID]
+			  ,[SiteName]
+			  ,[LibraryFolder]
+			  ,[FilePath]
+			  ,[FileTitle]
+			  ,[FileDescription] */
+
+			allData.Tables[3].TableName = "BizFormAttachmentRecords";
+
+			//Next, let's go through the three cases:
+
+			var siteSettings = new AllSiteSettings(allData);
+			var ResultSet = new DataSet();
+			ResultSet.Tables.Add(allData.Tables["MediaLibraryRecords"].Clone());
+			ResultSet.Tables[0].TableName = "MediaLibraryMissingRecords";
+
+			/* Media Library:
+			 * //MediaLibraryBaseFolder/SiteName?/folder/image.filetype
+			 */
+			foreach(DataRow row in allData.Tables["MediaLibraryRecords"].Rows)
+			{
+				var siteID = Convert.ToInt32(row["FileSiteID"]);
+				var rowURL = UriExtensions.Combine(siteSettings[siteID].baseMediaFolder, row["LibraryFolder"].ToString(), row["FilePath"].ToString());
+				if(!UriExtensions.Exists(rowURL))
+					ResultSet.Tables["MediaLibraryMissingRecords"].Rows.Add(row.ItemArray);
+			}
+
+			return new ModuleResults
+			{
+				Result = ResultSet,
+			};
+		}
+
+		/// <summary>
+		/// This class organizes the various Folder settings per-site, so I can just query for the base folder for a given site/object combination.
+		/// </summary>
+		private class AllSiteSettings : Dictionary<int, PerSiteSettings>
+		{
+			public AllSiteSettings(DataSet settingsData)
+			{
+				foreach(DataRow siteRow in settingsData.Tables["KenticoSites"].Rows)
+				{
+					this.Add(siteRow.Field<int>("SiteID"), new PerSiteSettings(siteRow.Field<int>("SiteID"), siteRow.Field<string>("SiteName"), settingsData.Tables["KenticoSettings"]));
+				}
+			}
+
+			public string GetBaseMediaFolder(int siteID)
+			{
+				return this[siteID].baseMediaFolder;
+			}
+
+			public string GetBaseFormAttachmentsFolder(int siteID)
+			{
+				return this[siteID].baseFormAttachmentsFolder;
+			}
+		}
+
+		/// <summary>
+		/// Provides a single Kentico Site's settings for getting the Media Library and Bizform base folders.
+		/// </summary>
+		private class PerSiteSettings
+		{
+			public PerSiteSettings(int siteID, string siteName, DataTable settingsTable)
+			{
+				baseMediaFolder = $"~/{siteName}/media";
+				baseFormAttachmentsFolder = $"~/{siteName}/BizFormFiles";
+
+				DataTable siteSettings = new DataView(settingsTable, $"SiteID = {siteID}", "KeyName", DataViewRowState.CurrentRows).ToTable();
+				DataTable globalSettings = new DataView(settingsTable, "SiteID is null", "KeyName", DataViewRowState.CurrentRows).ToTable();
+
+				var baseMediaFolderData = siteSettings.Select($"KeyName = 'CMSMediaLibrariesFolder'");
+				var baseMediaUseSiteData = siteSettings.Select($"KeyName = 'CMSUseMediaLibrariesSiteFolder'");
+				var baseFormAttachmentFolderData = siteSettings.Select($"KeyName = 'CMSBizFormFilesFolder'");
+				var baseFormAttachmentsUseSiteData = siteSettings.Select($"KeyName = 'CMSUseBizFormsSiteFolder'");
+
+				if(baseMediaFolderData.GetLength(0) == 0) baseMediaFolderData = globalSettings.Select($"KeyName = 'CMSMediaLibrariesFolder'");
+				if(baseMediaUseSiteData.GetLength(0) == 0) baseMediaUseSiteData = globalSettings.Select($"KeyName = 'CMSUseMediaLibrariesSiteFolder'");
+				if(baseFormAttachmentFolderData.GetLength(0) == 0) baseFormAttachmentFolderData = globalSettings.Select($"KeyName = 'CMSBizFormFilesFolder'");
+				if(baseFormAttachmentsUseSiteData.GetLength(0) == 0) baseFormAttachmentsUseSiteData = globalSettings.Select($"KeyName = 'CMSUseBizFormsSiteFolder'");
+
+				var baseMediaFolderString = baseMediaFolderData[0]["KeyValue"] as String;
+				var baseMediaUseSiteBool = Convert.ToBoolean(baseMediaUseSiteData[0]["KeyValue"]);
+				var baseFormAttachmentFolderString = baseFormAttachmentFolderData[0]["KeyValue"] as String;
+				var baseFormAttachmentsUseSiteBool = Convert.ToBoolean(baseFormAttachmentsUseSiteData[0]["KeyValue"]);
+
+				if(!String.IsNullOrWhiteSpace(baseMediaFolderString))
+				{
+					baseMediaFolder = UriExtensions.Combine(baseMediaFolderString, (baseMediaUseSiteBool ? $"{siteName}" : ""));
+				}
+				if(!String.IsNullOrWhiteSpace(baseFormAttachmentFolderString))
+				{
+					baseFormAttachmentsFolder = UriExtensions.Combine(baseFormAttachmentFolderString, (baseFormAttachmentsUseSiteBool ? $"{siteName}" : ""));
+				}
+			}
+
+			public string baseMediaFolder;
+
+			public string baseFormAttachmentsFolder;
+		}
+
+		/// <summary>
+		/// This class provides some extensions for dealing with the fact that we aren't in Kentico's context.
+		/// </summary>
+		private class UriExtensions
+		{
+			/// <summary>
+			/// This method does not work currently, but should return whether the file path passed in exists.
+			/// </summary>
+			/// <param name="baseUri">The virtual, server, or physical path</param>
+			/// <returns></returns>
+			public static bool Exists(string baseUri)
+			{
+				if(baseUri == null)
+				{
+					throw new ArgumentNullException($"baseUri of '{baseUri}' is null");
+				}
+
+				throw new NotImplementedException();
+			}
+
+			/// <summary>
+			/// Combines a base url with a list of folders afterwards.
+			/// </summary>
+			/// <param name="baseUri">The virtual, server, or physical path of origination</param>
+			/// <param name="addUris">Any number of additional strings for URI additions.</param>
+			/// <returns></returns>
+			public static string Combine(string baseUri, params string[] addUris)
+			{
+				if(baseUri == null)
+				{
+					throw new ArgumentNullException($"baseUri of '{baseUri}' is null");
+				}
+
+				if(addUris.Length == 0)
+				{
+					throw new ArgumentNullException("addUris was empty");
+				}
+
+				if(baseUri.StartsWith("~/"))
+				{
+					string combinedUrl = baseUri;
+					foreach(var addUri in addUris) 
+					{
+						combinedUrl = System.Web.VirtualPathUtility.AppendTrailingSlash(new Uri(combinedUrl, UriKind.Relative).ToString());
+						combinedUrl = System.Web.VirtualPathUtility.Combine(combinedUrl, new Uri(addUri, UriKind.Relative).ToString());
+					}
+
+					return new Uri(combinedUrl, UriKind.Relative).ToString();
+				}
+				else
+				{
+					var allUris = new string[addUris.Length + 1];
+					allUris[0] = baseUri;
+					addUris.CopyTo(allUris, 1);
+					return Path.Combine(allUris);
+				}
+			}
+		}
+	}
+}

--- a/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
@@ -26,7 +26,7 @@ namespace Kentico.KInspector.Modules
 @"Compares the list of Attachments and Media Library items against the database, to find:
 1) Media Library records not associated with any file in the filesystem.
 2) Form Attachments records not associated with any file in the filesystem.
-3) TODO: Form Attachments files not associated with any Form record in Kentico
+3) Form Attachments files not associated with any Form record in Kentico
 
 Note: Page attachments and metafiles can be administered in System->Files: https://docs.kentico.com/display/K9/Administering+files+globally",
 				Category = "Content"

--- a/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
@@ -7,168 +7,71 @@ using Kentico.KInspector.Core;
 
 namespace Kentico.KInspector.Modules
 {
-    public class DBFileConsistencyModule : IModule
-    {
-        public ModuleMetadata GetModuleMetadata()
-        {
-            return new ModuleMetadata
-            {
-                Name = "Form Attachments and Media Library Consistency Check",
-                SupportedVersions = new[] {
-                    new Version("6.0"),
-                    new Version("7.0"),
-                    new Version("8.0"),
-                    new Version("8.1"),
-                    new Version("8.2"),
-                    new Version("9.0")
-                },
-                Comment =
+	public class DBFileConsistencyModule: IModule
+	{
+		public ModuleMetadata GetModuleMetadata()
+		{
+			return new ModuleMetadata
+			{
+				Name = "Form Attachments and Media Library Consistency Check",
+				SupportedVersions = new[] {
+					new Version("6.0"),
+					new Version("7.0"),
+					new Version("8.0"),
+					new Version("8.1"),
+					new Version("8.2"),
+					new Version("9.0")
+				},
+				Comment =
 @"Compares the list of Attachments and Media Library items against the database, to find:
 1) Media Library records not associated with any file in the filesystem.
 2) Form Attachments records not associated with any file in the filesystem.
 3) Form Attachments files not associated with any Form record in Kentico
 
 Note: Page attachments and metafiles can be administered in System->Files: https://docs.kentico.com/display/K9/Administering+files+globally",
-                Category = "Content"
-            };
-        }
+				Category = "Content"
+			};
+		}
 
-        public ModuleResults GetResults(IInstanceInfo instanceInfo)
-        {
-            var allData = GetAllData(instanceInfo);
-            var siteSettings = new AllSiteSettings(allData);
-            var resultSet = new DataSet();
+		public ModuleResults GetResults(IInstanceInfo instanceInfo)
+		{
+			var allData = GetAllData(instanceInfo);
+			var siteSettings = new AllSiteSettings(allData);
+			var resultSet = new DataSet();
 
-            ProcessMediaLibraryRecords(instanceInfo, allData, siteSettings, resultSet);
 
-            resultSet.Tables.Add(allData.Tables["BizFormAttachmentRecords"].Clone());
-            resultSet.Tables[1].TableName = "BizFormAttachmentMissingFiles";
-            resultSet.Tables[1].Columns.Add("FileName");
-            resultSet.Tables[1].Columns.Add("AttachmentURL");
+			ProcessMediaLibraryRecords(instanceInfo, allData, siteSettings, resultSet);
+			Dictionary<int, Dictionary<string, bool>> fileItems = GetFormAttachmentFiles(instanceInfo, allData, siteSettings);
 
-            resultSet.Tables.Add(new DataTable());
-            resultSet.Tables[2].TableName = "BizFormAttachmentMissingRecords";
-            resultSet.Tables[2].Columns.Add("SiteID");
-            resultSet.Tables[2].Columns.Add("AttachmentGUID");
+			ProcessMissingFormAttachmentFiles(instanceInfo, allData, siteSettings, resultSet, fileItems);
 
-            Dictionary<int, Dictionary<string, bool>> fileItems = new Dictionary<int, Dictionary<string, bool>>();
+			ProcessMissingFormAttachmentRecords(resultSet, fileItems);
 
-            foreach (DataRow siteRow in allData.Tables["KenticoSites"].Rows)
-            {
-                var siteID = Convert.ToInt32(siteRow["SiteID"]);
-                fileItems.Add(siteID, new Dictionary<string, bool>());
-                foreach (var fileObj in UriExtensions.GetFiles(siteSettings[siteID].baseFormAttachmentsFolder, true, instanceInfo))
-                {
-                    fileItems[siteID].Add(fileObj.Name, false);
-                }
-            }
+			ApplyUserFriendlyTableNames(resultSet);
 
-            /* bizform Attachments:
-			 * //UploadedFormFiles/SiteName?/unknownguid.filetype)
-			 * AttachmentGuid is unknownguid.filetype/filename.filetype
-			 */
-            foreach (DataRow row in allData.Tables["BizFormAttachmentRecords"].Rows)
-            {
-                var siteID = Convert.ToInt32(row["SiteID"]);
-                var guidSplit = row["AttachmentGUID"].ToString().Split(new char[] { '/' }, 2);
-                if (guidSplit.Length != 2) { throw new ApplicationException($"AttachmentGUID of '{row["AttachmentGUID"].ToString()}' expected a '/' but did not find one."); }
-                var rowURL = UriExtensions.Combine(siteSettings[siteID].baseFormAttachmentsFolder, guidSplit[0]);
-                if (!UriExtensions.Exists(rowURL, instanceInfo))
-                {
-                    /* [AttachmentGUID]
-					 * ,[SiteID]
-					 * ,[TableName]
-					 * ,[FileName]
-					 * ,[AttachmentURL] 
-					 */
-                    var tempArray = new List<object>(row.ItemArray);
-                    tempArray[0] = guidSplit[0];
-                    tempArray.Add(guidSplit[1]);
-                    tempArray.Add(rowURL);
-                    resultSet.Tables["BizFormAttachmentMissingFiles"].Rows.Add(tempArray.ToArray());
-                }
+			return new ModuleResults
+			{
+				Result = resultSet,
+			};
+		}
 
-                if (fileItems[siteID].ContainsKey(guidSplit[0]))
-                {
-                    fileItems[siteID][guidSplit[0]] = true;
-                }
-            }
+		private DataSet GetAllData(IInstanceInfo instanceInfo)
+		{
+			var dbService = instanceInfo.DBService;
 
-            foreach (var siteItem in fileItems)
-            {
-                foreach (var record in siteItem.Value)
-                {
-                    if (record.Value == false)
-                    {
-                        var tempArray = new List<object>();
-                        tempArray.Add(siteItem.Key);
-                        tempArray.Add(record.Key);
-                        resultSet.Tables["BizFormAttachmentMissingRecords"].Rows.Add(tempArray.ToArray());
-                    }
-                }
-            }
-
-            resultSet.Tables[0].TableName = "1) Media Library, Missing Files";
-            resultSet.Tables[1].TableName = "2) BizForm Attachments, Missing Files";
-            resultSet.Tables[2].TableName = "3) BizForm Attachments, Missing Records";
-
-            return new ModuleResults
-            {
-                Result = resultSet,
-            };
-        }
-
-        private static void ProcessMediaLibraryRecords(IInstanceInfo instanceInfo, DataSet allData, AllSiteSettings siteSettings, DataSet ResultSet)
-        {
-            AddMediaLibraryResultsTable(allData, ResultSet);
-
-            foreach (DataRow row in allData.Tables["MediaLibraryRecords"].Rows)
-            {
-                var siteID = Convert.ToInt32(row["FileSiteID"]);
-                var siteBaseFolder = siteSettings[siteID].baseMediaFolder;
-                var libraryFolder = row["LibraryFolder"].ToString();
-                var filePath = row["FilePath"].ToString();
-                var fullFilePath = UriExtensions.Combine(siteBaseFolder, libraryFolder, filePath);
-
-                if (!UriExtensions.Exists(fullFilePath, instanceInfo))
-                {
-                    var tempArray = AddAttachmentUrlToMediaRecord(row, fullFilePath);
-                    ResultSet.Tables["MediaLibraryMissingFiles"].Rows.Add(tempArray);
-                }
-            }
-        }
-
-        private static object[] AddAttachmentUrlToMediaRecord(DataRow row, string fullFilePath)
-        {
-            var tempArray = new List<object>(row.ItemArray);
-            tempArray.Add(fullFilePath);
-            return tempArray.ToArray();
-        }
-
-        private static void AddMediaLibraryResultsTable(DataSet allData, DataSet ResultSet)
-        {
-            ResultSet.Tables.Add(allData.Tables["MediaLibraryRecords"].Clone());
-            ResultSet.Tables[0].TableName = "MediaLibraryMissingFiles";
-            ResultSet.Tables[0].Columns.Add("AttachmentURL");
-        }
-
-        private DataSet GetAllData(IInstanceInfo instanceInfo)
-        {
-            var dbService = instanceInfo.DBService;
-
-            var allData = dbService.ExecuteAndGetDataSetFromFile("GetLibraryAndAttachmentFiles.sql");
-            allData.Tables[0].TableName = "KenticoSites";
-            /* [SiteID]
+			var allData = dbService.ExecuteAndGetDataSetFromFile("GetLibraryAndAttachmentFiles.sql");
+			allData.Tables[0].TableName = "KenticoSites";
+			/* [SiteID]
 			  ,[SiteName] */
 
-            allData.Tables[1].TableName = "KenticoSettings";
-            /* [CategoryName]
+			allData.Tables[1].TableName = "KenticoSettings";
+			/* [CategoryName]
 			  ,[KeyName]
 			  ,[KeyValue]
 			  ,[SiteID] */
 
-            allData.Tables[2].TableName = "MediaLibraryRecords";
-            /* [FileName]
+			allData.Tables[2].TableName = "MediaLibraryRecords";
+			/* [FileName]
 			  ,[FileSiteID]
 			  ,[SiteName]
 			  ,[LibraryFolder]
@@ -176,194 +79,342 @@ Note: Page attachments and metafiles can be administered in System->Files: https
 			  ,[FileTitle]
 			  ,[FileDescription] */
 
-            allData.Tables[3].TableName = "BizFormAttachmentRecords";
-            /* [AttachmentGUID]
+			allData.Tables[3].TableName = "BizFormAttachmentRecords";
+			/* [AttachmentGUID]
 			 * ,[SiteID]
 			 * ,[TableName]
 			 */
-            return allData;
-        }
+			return allData;
+		}
 
-        /// <summary>
-        /// This class organizes the various Folder settings per-site, so I can just query for the base folder for a given site/object combination.
-        /// </summary>
-        private class AllSiteSettings : Dictionary<int, PerSiteSettings>
-        {
-            public AllSiteSettings(DataSet settingsData)
-            {
-                foreach (DataRow siteRow in settingsData.Tables["KenticoSites"].Rows)
-                {
-                    this.Add(siteRow.Field<int>("SiteID"), new PerSiteSettings(siteRow.Field<int>("SiteID"), siteRow.Field<string>("SiteName"), settingsData.Tables["KenticoSettings"]));
-                }
-            }
+		private static void ProcessMediaLibraryRecords(IInstanceInfo instanceInfo, DataSet allData, AllSiteSettings siteSettings, DataSet ResultSet)
+		{
+			AddMediaLibraryResultsTable(allData, ResultSet);
 
-            public string GetBaseMediaFolder(int siteID)
-            {
-                return this[siteID].baseMediaFolder;
-            }
+			foreach(DataRow row in allData.Tables["MediaLibraryRecords"].Rows)
+			{
+				/* Media Library:
+				 * //MediaLibraryBaseFolder/SiteName?/folder/image.filetype
+				 */
 
-            public string GetBaseFormAttachmentsFolder(int siteID)
-            {
-                return this[siteID].baseFormAttachmentsFolder;
-            }
-        }
+				var siteID = Convert.ToInt32(row["FileSiteID"]);
+				var siteBaseFolder = siteSettings[siteID].baseMediaFolder;
+				var libraryFolder = row["LibraryFolder"].ToString();
+				var filePath = row["FilePath"].ToString();
+				var fullFilePath = UriExtensions.Combine(siteBaseFolder, libraryFolder, filePath);
 
-        /// <summary>
-        /// Provides a single Kentico Site's settings for getting the Media Library and Bizform base folders.
-        /// </summary>
-        private class PerSiteSettings
-        {
-            public PerSiteSettings(int siteID, string siteName, DataTable settingsTable)
-            {
-                baseMediaFolder = $"~/{siteName}/media";
-                baseFormAttachmentsFolder = $"~/{siteName}/BizFormFiles";
+				if(!UriExtensions.Exists(fullFilePath, instanceInfo))
+				{
+					var tempArray = AddAttachmentUrlToMediaRecord(row, fullFilePath);
+					ResultSet.Tables["MediaLibraryMissingFiles"].Rows.Add(tempArray);
+				}
+			}
+		}
 
-                DataTable siteSettings = new DataView(settingsTable, $"SiteID = {siteID}", "KeyName", DataViewRowState.CurrentRows).ToTable();
-                DataTable globalSettings = new DataView(settingsTable, "SiteID is null", "KeyName", DataViewRowState.CurrentRows).ToTable();
+		private static void AddMediaLibraryResultsTable(DataSet allData, DataSet ResultSet)
+		{
+			/*[FileName]
+			  ,[FileSiteID]
+			  ,[SiteName]
+			  ,[LibraryFolder]
+			  ,[FilePath]
+			  ,[FileTitle]
+			  ,[FileDescription]
+			  ,[AttachmentURL] 
+			  */
+			ResultSet.Tables.Add(allData.Tables["MediaLibraryRecords"].Clone());
+			ResultSet.Tables[0].TableName = "MediaLibraryMissingFiles";
+			ResultSet.Tables[0].Columns.Add("AttachmentURL");
+		}
 
-                var baseMediaFolderData = siteSettings.Select($"KeyName = 'CMSMediaLibrariesFolder'");
-                var baseMediaUseSiteData = siteSettings.Select($"KeyName = 'CMSUseMediaLibrariesSiteFolder'");
-                var baseFormAttachmentFolderData = siteSettings.Select($"KeyName = 'CMSBizFormFilesFolder'");
-                var baseFormAttachmentsUseSiteData = siteSettings.Select($"KeyName = 'CMSUseBizFormsSiteFolder'");
+		private static object[] AddAttachmentUrlToMediaRecord(DataRow row, string fullFilePath)
+		{
+			var tempArray = new List<object>(row.ItemArray);
+			tempArray.Add(fullFilePath);
+			return tempArray.ToArray();
+		}
 
-                if (baseMediaFolderData.GetLength(0) == 0) baseMediaFolderData = globalSettings.Select($"KeyName = 'CMSMediaLibrariesFolder'");
-                if (baseMediaUseSiteData.GetLength(0) == 0) baseMediaUseSiteData = globalSettings.Select($"KeyName = 'CMSUseMediaLibrariesSiteFolder'");
-                if (baseFormAttachmentFolderData.GetLength(0) == 0) baseFormAttachmentFolderData = globalSettings.Select($"KeyName = 'CMSBizFormFilesFolder'");
-                if (baseFormAttachmentsUseSiteData.GetLength(0) == 0) baseFormAttachmentsUseSiteData = globalSettings.Select($"KeyName = 'CMSUseBizFormsSiteFolder'");
+		private static Dictionary<int, Dictionary<string, bool>> GetFormAttachmentFiles(IInstanceInfo instanceInfo, DataSet allData, AllSiteSettings siteSettings)
+		{
+			Dictionary<int, Dictionary<string, bool>> fileItems = new Dictionary<int, Dictionary<string, bool>>();
 
-                var baseMediaFolderString = baseMediaFolderData[0]["KeyValue"] as String;
-                var baseMediaUseSiteBool = Convert.ToBoolean(baseMediaUseSiteData[0]["KeyValue"]);
-                var baseFormAttachmentFolderString = baseFormAttachmentFolderData[0]["KeyValue"] as String;
-                var baseFormAttachmentsUseSiteBool = Convert.ToBoolean(baseFormAttachmentsUseSiteData[0]["KeyValue"]);
+			foreach(DataRow siteRow in allData.Tables["KenticoSites"].Rows)
+			{
+				var siteID = Convert.ToInt32(siteRow["SiteID"]);
+				fileItems.Add(siteID, new Dictionary<string, bool>());
+				foreach(var fileObj in UriExtensions.GetFiles(siteSettings[siteID].baseFormAttachmentsFolder, true, instanceInfo))
+				{
+					fileItems[siteID].Add(fileObj.Name, false);
+				}
+			}
 
-                if (!String.IsNullOrWhiteSpace(baseMediaFolderString))
-                {
-                    baseMediaFolder = UriExtensions.Combine(baseMediaFolderString, (baseMediaUseSiteBool ? $"{siteName}" : ""));
-                }
-                if (!String.IsNullOrWhiteSpace(baseFormAttachmentFolderString))
-                {
-                    baseFormAttachmentsFolder = UriExtensions.Combine(baseFormAttachmentFolderString, (baseFormAttachmentsUseSiteBool ? $"{siteName}" : ""));
-                }
+			return fileItems;
+		}
+		
+		private static void ProcessMissingFormAttachmentFiles(IInstanceInfo instanceInfo, DataSet allData, AllSiteSettings siteSettings, DataSet resultSet, Dictionary<int, Dictionary<string, bool>> fileItems)
+		{
+			AddMissingFormAttachmentFilesTable(allData, resultSet);
 
-                if (!Regex.IsMatch(baseMediaFolder, "^[a-zA-Z]:/.*")
-                && !Regex.IsMatch(baseMediaFolder, "^~/.*")
-                && !Regex.IsMatch(baseMediaFolder, "^\\\\.*"))
-                {
-                    throw new ArgumentException($"This method supports Kentico's three suggested file formats: '\\servername\', 'c:/', and '~/'. Your Media library setting of '{baseMediaFolder}' does not match these.");
-                }
+			/* bizform Attachments:
+			 * //UploadedFormFiles/SiteName?/unknownguid.filetype)
+			 * AttachmentGuid is unknownguid.filetype/filename.filetype
+			 */
+			foreach(DataRow row in allData.Tables["BizFormAttachmentRecords"].Rows)
+			{
+				var siteID = Convert.ToInt32(row["SiteID"]);
+				var guidSplit = row["AttachmentGUID"].ToString().Split(new char[] { '/' }, 2);
+				if(guidSplit.Length != 2)
+					{ throw new ApplicationException($"AttachmentGUID of '{row["AttachmentGUID"].ToString()}' expected a '/' but did not find one."); }
+				var rowURL = UriExtensions.Combine(siteSettings[siteID].baseFormAttachmentsFolder, guidSplit[0]);
+				if(!UriExtensions.Exists(rowURL, instanceInfo))
+				{
+					var tempArray = new List<object>(row.ItemArray);
+					tempArray[0] = guidSplit[0];
+					tempArray.Add(guidSplit[1]);
+					tempArray.Add(rowURL);
+					resultSet.Tables["BizFormAttachmentMissingFiles"].Rows.Add(tempArray.ToArray());
+				}
 
-                if (!Regex.IsMatch(baseFormAttachmentsFolder, "^[a-zA-Z]:/.*")
-                && !Regex.IsMatch(baseFormAttachmentsFolder, "^~/.*")
-                && !Regex.IsMatch(baseFormAttachmentsFolder, "^\\\\.*"))
-                {
-                    throw new ArgumentException($"This method supports Kentico's three suggested file formats: '\\servername\', 'c:/', and '~/'. Your Form Attachment setting of '{baseFormAttachmentsFolder}' does not match these.");
-                }
+				if(fileItems[siteID].ContainsKey(guidSplit[0]))
+				{
+					fileItems[siteID][guidSplit[0]] = true;
+				}
+			}
+		}
 
-            }
+		private static void AddMissingFormAttachmentFilesTable(DataSet allData, DataSet resultSet)
+		{
+			/* [AttachmentGUID]
+			 * ,[SiteID]
+			 * ,[TableName]
+			 * ,[FileName]
+			 * ,[AttachmentURL] 
+			 */
+			resultSet.Tables.Add(allData.Tables["BizFormAttachmentRecords"].Clone());
+			resultSet.Tables[1].TableName = "BizFormAttachmentMissingFiles";
+			resultSet.Tables[1].Columns.Add("FileName");
+			resultSet.Tables[1].Columns.Add("AttachmentURL");
+		}
 
-            public string baseMediaFolder;
+		private static void ProcessMissingFormAttachmentRecords(DataSet resultSet, Dictionary<int, Dictionary<string, bool>> fileItems)
+		{
+			AddMissingFormAttachmentRecordsTable(resultSet);
 
-            public string baseFormAttachmentsFolder;
-        }
+			/* bizform Attachments:
+			 * //UploadedFormFiles/SiteName?/unknownguid.filetype)
+			 * AttachmentGuid is unknownguid.filetype/filename.filetype
+			 */
+			foreach(var siteItem in fileItems)
+			{
+				foreach(var record in siteItem.Value)
+				{
+					if(record.Value == false)
+					{
+						var tempArray = new List<object>();
+						tempArray.Add(siteItem.Key);
+						tempArray.Add(record.Key);
+						resultSet.Tables["BizFormAttachmentMissingRecords"].Rows.Add(tempArray.ToArray());
+					}
+				}
+			}
+		}
 
-        /// <summary>
-        /// This class provides some extensions for dealing with the fact that we aren't in Kentico's context.
-        /// </summary>
-        private class UriExtensions
-        {
-            /// <summary>
-            /// This method should return whether the file path passed in exists.
-            /// </summary>
-            /// <param name="baseUri">The virtual, server, or physical path</param>
-            /// <returns></returns>
-            public static bool Exists(string baseUri, IInstanceInfo info)
-            {
-                if (baseUri == null)
-                {
-                    throw new ArgumentNullException($"baseUri value is null");
-                }
+		private static void AddMissingFormAttachmentRecordsTable(DataSet resultSet)
+		{
+			/* [SiteID]
+			 * ,[AttachmentGUID] 
+			 */
+			resultSet.Tables.Add(new DataTable());
+			resultSet.Tables[2].TableName = "BizFormAttachmentMissingRecords";
+			resultSet.Tables[2].Columns.Add("SiteID");
+			resultSet.Tables[2].Columns.Add("AttachmentGUID");
+		}
 
-                try
-                {
+		private static void ApplyUserFriendlyTableNames(DataSet resultSet)
+		{
+			resultSet.Tables[0].TableName = "1) Media Library, Missing Files";
+			resultSet.Tables[1].TableName = "2) BizForm Attachments, Missing Files";
+			resultSet.Tables[2].TableName = "3) BizForm Attachments, Missing Records";
+		}
 
-                    if (baseUri.StartsWith("~/"))
-                    {
-                        //If we're using a relative path, it's relative to the "CMS" folder, not the Kentico base folder.
-                        var absPath = Combine(info.Directory.FullName, "CMS", baseUri.Substring(2));
-                        return File.Exists(absPath);
-                    }
-                    else
-                        return File.Exists(baseUri);
+		/// <summary>
+		/// This class organizes the various Folder settings per-site, so I can just query for the base folder for a given site/object combination.
+		/// </summary>
+		private class AllSiteSettings: Dictionary<int, PerSiteSettings>
+		{
+			public AllSiteSettings(DataSet settingsData)
+			{
+				foreach(DataRow siteRow in settingsData.Tables["KenticoSites"].Rows)
+				{
+					this.Add(siteRow.Field<int>("SiteID"), new PerSiteSettings(siteRow.Field<int>("SiteID"), siteRow.Field<string>("SiteName"), settingsData.Tables["KenticoSettings"]));
+				}
+			}
 
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
+			public string GetBaseMediaFolder(int siteID)
+			{
+				return this[siteID].baseMediaFolder;
+			}
 
-            }
+			public string GetBaseFormAttachmentsFolder(int siteID)
+			{
+				return this[siteID].baseFormAttachmentsFolder;
+			}
+		}
 
-            /// <summary>
-            /// This method should return whether the file path passed in exists.
-            /// </summary>
-            /// <param name="baseUri">The virtual, server, or physical path</param>
-            /// <returns></returns>
-            public static FileInfo[] GetFiles(string baseUri, bool recursive, IInstanceInfo info)
-            {
-                if (baseUri == null)
-                {
-                    throw new ArgumentNullException($"baseUri value is null");
-                }
+		/// <summary>
+		/// Provides a single Kentico Site's settings for getting the Media Library and Bizform base folders.
+		/// </summary>
+		private class PerSiteSettings
+		{
+			public PerSiteSettings(int siteID, string siteName, DataTable settingsTable)
+			{
+				baseMediaFolder = $"~/{siteName}/media";
+				baseFormAttachmentsFolder = $"~/{siteName}/BizFormFiles";
 
-                if (baseUri.StartsWith("~/"))
-                {
-                    //If we're using a relative path, it's relative to the "CMS" folder, not the Kentico base folder.
-                    var absPath = Combine(info.Directory.FullName, baseUri.Substring(2));
-                    return new DirectoryInfo(absPath).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-                }
-                else
-                    return new DirectoryInfo(baseUri).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-            }
+				DataTable siteSettings = new DataView(settingsTable, $"SiteID = {siteID}", "KeyName", DataViewRowState.CurrentRows).ToTable();
+				DataTable globalSettings = new DataView(settingsTable, "SiteID is null", "KeyName", DataViewRowState.CurrentRows).ToTable();
 
-            /// <summary>
-            /// Combines a base url with a list of folders afterwards.
-            /// </summary>
-            /// <param name="baseUri">The virtual, server, or physical path of origination</param>
-            /// <param name="addUris">Any number of additional strings for URI additions.</param>
-            /// <returns></returns>
-            public static string Combine(string baseUri, params string[] addUris)
-            {
-                if (baseUri == null)
-                {
-                    throw new ArgumentNullException($"baseUri value is null");
-                }
+				var baseMediaFolderData = siteSettings.Select($"KeyName = 'CMSMediaLibrariesFolder'");
+				var baseMediaUseSiteData = siteSettings.Select($"KeyName = 'CMSUseMediaLibrariesSiteFolder'");
+				var baseFormAttachmentFolderData = siteSettings.Select($"KeyName = 'CMSBizFormFilesFolder'");
+				var baseFormAttachmentsUseSiteData = siteSettings.Select($"KeyName = 'CMSUseBizFormsSiteFolder'");
 
-                if (addUris.Length == 0)
-                {
-                    throw new ArgumentNullException("addUris was empty");
-                }
+				if(baseMediaFolderData.GetLength(0) == 0) baseMediaFolderData = globalSettings.Select($"KeyName = 'CMSMediaLibrariesFolder'");
+				if(baseMediaUseSiteData.GetLength(0) == 0) baseMediaUseSiteData = globalSettings.Select($"KeyName = 'CMSUseMediaLibrariesSiteFolder'");
+				if(baseFormAttachmentFolderData.GetLength(0) == 0) baseFormAttachmentFolderData = globalSettings.Select($"KeyName = 'CMSBizFormFilesFolder'");
+				if(baseFormAttachmentsUseSiteData.GetLength(0) == 0) baseFormAttachmentsUseSiteData = globalSettings.Select($"KeyName = 'CMSUseBizFormsSiteFolder'");
 
-                if (baseUri.StartsWith("~/"))
-                {
-                    string combinedUrl = baseUri;
-                    foreach (var addUri in addUris)
-                    {
-                        combinedUrl = System.Web.VirtualPathUtility.AppendTrailingSlash(new Uri(combinedUrl, UriKind.Relative).ToString());
-                        combinedUrl = System.Web.VirtualPathUtility.Combine(combinedUrl, new Uri(addUri, UriKind.Relative).ToString());
-                    }
+				var baseMediaFolderString = baseMediaFolderData[0]["KeyValue"] as String;
+				var baseMediaUseSiteBool = Convert.ToBoolean(baseMediaUseSiteData[0]["KeyValue"]);
+				var baseFormAttachmentFolderString = baseFormAttachmentFolderData[0]["KeyValue"] as String;
+				var baseFormAttachmentsUseSiteBool = Convert.ToBoolean(baseFormAttachmentsUseSiteData[0]["KeyValue"]);
 
-                    return new Uri(combinedUrl, UriKind.Relative).ToString();
-                }
-                else
-                {
-                    bool usesForwardSlash = Regex.IsMatch(baseUri, "^[a-zA-Z]:/.*");
-                    var allUris = new string[addUris.Length + 1];
-                    allUris[0] = baseUri;
-                    addUris.CopyTo(allUris, 1);
-                    var combinedPath = Path.Combine(allUris);
-                    return !usesForwardSlash ? combinedPath : combinedPath.Replace('\\', '/');
-                }
-            }
-        }
-    }
+				if(!String.IsNullOrWhiteSpace(baseMediaFolderString))
+				{
+					baseMediaFolder = UriExtensions.Combine(baseMediaFolderString, (baseMediaUseSiteBool ? $"{siteName}" : ""));
+				}
+				if(!String.IsNullOrWhiteSpace(baseFormAttachmentFolderString))
+				{
+					baseFormAttachmentsFolder = UriExtensions.Combine(baseFormAttachmentFolderString, (baseFormAttachmentsUseSiteBool ? $"{siteName}" : ""));
+				}
+
+				if(!Regex.IsMatch(baseMediaFolder, "^[a-zA-Z]:/.*")
+				&& !Regex.IsMatch(baseMediaFolder, "^~/.*")
+				&& !Regex.IsMatch(baseMediaFolder, "^\\\\.*"))
+				{
+					throw new ArgumentException($"This method supports Kentico's three suggested file formats: '\\servername\', 'c:/', and '~/'. Your Media library setting of '{baseMediaFolder}' does not match these.");
+				}
+
+				if(!Regex.IsMatch(baseFormAttachmentsFolder, "^[a-zA-Z]:/.*")
+				&& !Regex.IsMatch(baseFormAttachmentsFolder, "^~/.*")
+				&& !Regex.IsMatch(baseFormAttachmentsFolder, "^\\\\.*"))
+				{
+					throw new ArgumentException($"This method supports Kentico's three suggested file formats: '\\servername\', 'c:/', and '~/'. Your Form Attachment setting of '{baseFormAttachmentsFolder}' does not match these.");
+				}
+
+			}
+
+			public string baseMediaFolder;
+
+			public string baseFormAttachmentsFolder;
+		}
+
+		/// <summary>
+		/// This class provides some extensions for dealing with the fact that we aren't in Kentico's context.
+		/// </summary>
+		private class UriExtensions
+		{
+			/// <summary>
+			/// This method should return whether the file path passed in exists.
+			/// </summary>
+			/// <param name="baseUri">The virtual, server, or physical path</param>
+			/// <returns></returns>
+			public static bool Exists(string baseUri, IInstanceInfo info)
+			{
+				if(baseUri == null)
+				{
+					throw new ArgumentNullException($"baseUri value is null");
+				}
+
+				try
+				{
+
+					if(baseUri.StartsWith("~/"))
+					{
+						var absPath = Combine(info.Directory.FullName, baseUri.Substring(2));
+						return File.Exists(absPath);
+					}
+					else
+						return File.Exists(baseUri);
+
+				}
+				catch(Exception ex)
+				{
+					throw ex;
+				}
+
+			}
+
+			/// <summary>
+			/// This method should return whether the file path passed in exists.
+			/// </summary>
+			/// <param name="baseUri">The virtual, server, or physical path</param>
+			/// <returns></returns>
+			public static FileInfo[] GetFiles(string baseUri, bool recursive, IInstanceInfo info)
+			{
+				if(baseUri == null)
+				{
+					throw new ArgumentNullException($"baseUri value is null");
+				}
+
+				if(baseUri.StartsWith("~/"))
+				{
+					var absPath = Combine(info.Directory.FullName, baseUri.Substring(2));
+					return new DirectoryInfo(absPath).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+				}
+				else
+					return new DirectoryInfo(baseUri).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+			}
+
+			/// <summary>
+			/// Combines a base url with a list of folders afterwards.
+			/// </summary>
+			/// <param name="baseUri">The virtual, server, or physical path of origination</param>
+			/// <param name="addUris">Any number of additional strings for URI additions.</param>
+			/// <returns></returns>
+			public static string Combine(string baseUri, params string[] addUris)
+			{
+				if(baseUri == null)
+				{
+					throw new ArgumentNullException($"baseUri value is null");
+				}
+
+				if(addUris.Length == 0)
+				{
+					throw new ArgumentNullException("addUris was empty");
+				}
+
+				if(baseUri.StartsWith("~/"))
+				{
+					string combinedUrl = baseUri;
+					foreach(var addUri in addUris)
+					{
+						combinedUrl = System.Web.VirtualPathUtility.AppendTrailingSlash(new Uri(combinedUrl, UriKind.Relative).ToString());
+						combinedUrl = System.Web.VirtualPathUtility.Combine(combinedUrl, new Uri(addUri, UriKind.Relative).ToString());
+					}
+
+					return new Uri(combinedUrl, UriKind.Relative).ToString();
+				}
+				else
+				{
+					bool usesForwardSlash = Regex.IsMatch(baseUri, "^[a-zA-Z]:/.*");
+					var allUris = new string[addUris.Length + 1];
+					allUris[0] = baseUri;
+					addUris.CopyTo(allUris, 1);
+					var combinedPath = Path.Combine(allUris);
+					return !usesForwardSlash ? combinedPath : combinedPath.Replace('\\', '/');
+				}
+			}
+		}
+	}
 }

--- a/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
+++ b/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
@@ -35,15 +35,16 @@ SELECT [FileName]
 /* Script to get BizForm attachment values */
 
 
-declare @t table( tablename varchar(50), columnname varchar(50))
+declare @t table( siteID varchar(50), tablename varchar(50), columnname varchar(50))
 declare @sql varchar(max)
 set @sql = ''
 
 /* Use XML to parse the Form defintion, find any Attachment-type records (Text using UploadControl) */
 
 insert into @t
-select ClassTableName, T.N.value('@column', 'varchar(50)') as name
+select CMS_Form.FormSiteID, ClassTableName, T.N.value('@column', 'varchar(50)') as name
 from CMS_Class
+inner join CMS_Form on CMS_Form.FormClassID = CMS_Class.ClassID
 cross apply (select cast(ClassFormDefinition as xml)) as X(y)
 cross apply X.y.nodes('/form/field[@columntype="text"][settings/controlname="UploadControl"]') T(N)
  where 
@@ -51,7 +52,8 @@ ClassIsForm = 1
 
 /* Build a query for each of these, getting all of the attachment items within each table */
 
-select @sql = @sql + 'Select [' + columnname + '] From ' + tablename + ' union ' from @t
+select @sql = @sql + 'Select [' + columnname + '] as AttachmentGUID, ' + siteID + ' as SiteID, ''' + tablename + ''' as TableName From ' + tablename + ' where [' + columnname + '] is not null union ' from @t
+
 
 --remove the trailing 'union'
 Select @sql = substring(@sql, 1, len(@sql) - 6)

--- a/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
+++ b/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
@@ -1,0 +1,59 @@
+﻿
+/****** Script for getting the list of all sites  ******/
+
+select [SiteID]
+      ,[SiteName]
+from CMS_Site
+
+/****** Script for getting the settings that decide where the files are stored in the filesystem  ******/
+
+select [CategoryName]
+      ,[KeyName]
+	  ,[KeyValue]
+	  ,[SiteID]
+from CMS_SettingsKey
+inner join CMS_SettingsCategory on CMS_SettingsKey.KeyCategoryID = CMS_SettingsCategory.CategoryID
+where 
+KeyName in ('CMSMediaLibrariesFolder', 'CMSUseMediaLibrariesSiteFolder', 'CMSBizFormFilesFolder', 'CMSUseBizFormsSiteFolder') 
+and CategoryName in ('CMS.MediaLibraries.Storage', 'CMS.Files.Storage')
+order by CategoryName, KeyOrder
+
+/****** Script for Media Library Files  ******/
+
+SELECT [FileName]
+      ,[FileSiteID]
+      ,[SiteName]
+      ,[LibraryFolder]
+      ,[FilePath]
+	  ,[FileTitle]
+	  ,[FileDescription]
+  FROM [dbo].[Media_File]
+  inner join [dbo].[CMS_Site] on [dbo].[Media_File].[FileSiteID] = [dbo].[CMS_Site].[SiteID]
+  inner join [dbo].[Media_Library] on [dbo].[Media_File].[FileLibraryID] = [dbo].[Media_Library].[LibraryID]
+
+
+/* Script to get BizForm attachment values */
+
+
+declare @t table( tablename varchar(50), columnname varchar(50))
+declare @sql varchar(max)
+set @sql = ''
+
+/* Use XML to parse the Form defintion, find any Attachment-type records (Text using UploadControl) */
+
+insert into @t
+select ClassTableName, T.N.value('@column', 'varchar(50)') as name
+from CMS_Class
+cross apply (select cast(ClassFormDefinition as xml)) as X(y)
+cross apply X.y.nodes('/form/field[@columntype="text"][settings/controlname="UploadControl"]') T(N)
+ where 
+ClassIsForm = 1
+
+/* Build a query for each of these, getting all of the attachment items within each table */
+
+select @sql = @sql + 'Select [' + columnname + '] From ' + tablename + ' union ' from @t
+
+--remove the trailing 'union'
+Select @sql = substring(@sql, 1, len(@sql) - 6)
+
+exec (@sql)


### PR DESCRIPTION
This module adds three checks to the system:
1) Media Library records not associated with any file in the filesystem.
- This iterates over the media library and attempts to access the physical file for each. It then displays each record that was not found. This way the user can go find the missing file and re-add it if necessary.

2) Form Attachments records not associated with any file in the filesystem.
- This iterates over each bizform and finds any user-submitted attachments submitted. If Kentico believes one should exist, but the file is not in the file system, that record is returned and reported. This allows the owner to find any missing attachments that the user expects to have been submitted.

3) Form Attachments files not associated with any Form record in Kentico
- This iterates over each physical file in the Form Attachments folder, and then compares that list to the various forms' files. If no matching Form Attachment record is found, that file is reported. This allows the administrator to delete any file attachments that are no longer being tracked by Kentico.

It should properly work for all four supported Kentico cases of location storage: "C:/", "C:\", "\\server\" and "~/".

It does not support mixed-use folders: "c:/folder\subfolder/".  It also assumes that the KInspector package has file access to any Kentico attachment or media library item via the same pathing structure that the website uses. 
A future enhancement of this feature could use the Kentico public urls for the media library instead of attempting to access the files directly. This might allow us to run these tests without caring about the base folder structure - I'm not sure if there are edge cases where doing so would not return proper results.  
I don't believe there is a public URL for bizform attachments, so that case still needs to know the physical file structure.