### PR TITLE
If the site had no forms, this script would sql underflow at the end

### DIFF
--- a/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
@@ -16,8 +16,6 @@ namespace Kentico.KInspector.Modules
 			{
 				Name = "Form Attachments and Media Library Consistency Check",
 				SupportedVersions = new[] {
-					new Version("6.0"),
-					new Version("7.0"),
 					new Version("8.0"),
 					new Version("8.1"),
 					new Version("8.2"),

--- a/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
+++ b/KInspector.Modules/Modules/Content/DBFileConsistencyModule.cs
@@ -366,14 +366,21 @@ Note: Page attachments and metafiles can be administered in System->Files: https
 					throw new ArgumentNullException($"baseUri value is null");
 				}
 
-				if(baseUri.StartsWith("~/"))
+				try
 				{
-					var absPath = Combine(info.Directory.FullName, baseUri.Substring(2));
-					return new DirectoryInfo(absPath).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+					if(baseUri.StartsWith("~/"))
+					{
+						var absPath = Combine(info.Directory.FullName, baseUri.Substring(2));
+						return Directory.Exists(absPath) ? new DirectoryInfo(absPath).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly) : new FileInfo[] { };
+					}
+					else
+						return Directory.Exists(baseUri) ? new DirectoryInfo(baseUri).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly) : new FileInfo[] { };
 				}
-				else
-					return new DirectoryInfo(baseUri).GetFiles("*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-			}
+				catch(Exception ex)
+				{
+					throw ex;
+				}
+	}
 
 			/// <summary>
 			/// Combines a base url with a list of folders afterwards.

--- a/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
+++ b/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
@@ -56,6 +56,6 @@ select @sql = @sql + 'Select [' + columnname + '] as AttachmentGUID, ' + siteID 
 
 
 --remove the trailing 'union'
-Select @sql = substring(@sql, 1, len(@sql) - 6)
+Select @sql = substring(@sql, 1, IIF(len(@sql) - 6 >= 0, len(@sql) - 6, 0))
 
 exec (@sql)

--- a/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
+++ b/KInspector.Modules/Scripts/GetLibraryAndAttachmentFiles.sql
@@ -56,6 +56,6 @@ select @sql = @sql + 'Select [' + columnname + '] as AttachmentGUID, ' + siteID 
 
 
 --remove the trailing 'union'
-Select @sql = substring(@sql, 1, IIF(len(@sql) - 6 >= 0, len(@sql) - 6, 0))
+Select @sql = CASE WHEN  len(@sql) - 6 >= 0 THEN substring(@sql, 1, len(@sql) - 6) ELSE 'Select top 0 newid() as AttachmentGUID, 0 as SiteID, '''' as TableName' END
 
 exec (@sql)


### PR DESCRIPTION
This was causing a sql error that kept terminating the function. A check on the length of the sql query fixes this.