### PR TITLE
Adds a generic task processing issues module

### DIFF
--- a/KInspector.Modules/Kentico.KInspector.Modules.csproj
+++ b/KInspector.Modules/Kentico.KInspector.Modules.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Modules\Content\UnusedTemplatesModule.cs" />
     <Compile Include="Modules\Content\WebPartsInTransformationsModule.cs" />
     <Compile Include="Modules\Content\WorkflowConsistencyModule.cs" />
+    <Compile Include="Modules\General\TaskProcessingIssuesModule.cs" />
     <Compile Include="Modules\General\DebugCheckModule.cs" />
     <Compile Include="Modules\EventLog\EventLogErrorsModule.cs" />
     <Compile Include="Modules\Content\DuplicatePageAliasesModule.cs" />
@@ -219,6 +220,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Scripts\Setup\GlobalAdminSetupModule.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Scripts\TaskProcessingIssueModule.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Scripts\TransformationAnalyzerModule-GetDataWhereIn-KI_ClassNames.sql">

--- a/KInspector.Modules/Modules/General/TaskProcessingIssuesModule.cs
+++ b/KInspector.Modules/Modules/General/TaskProcessingIssuesModule.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Data;
+using Kentico.KInspector.Core;
+
+namespace Kentico.KInspector.Modules
+{
+    public class TaskProcessingIssues : IModule
+    {
+        public ModuleMetadata GetModuleMetadata()
+        {
+            return new ModuleMetadata
+            {
+                Name = "Task processing issues",
+                SupportedVersions = new[] {
+                    new Version("6.0"),
+                    new Version("7.0"),
+                    new Version("8.0"),
+                    new Version("8.1"),
+                    new Version("8.2"),
+                    new Version("9.0")
+                },
+                Comment = @"Checks for possible issues with processing system, workflow, marketing automation, smart search, and web farm tasks.",
+                Category = "Database"
+            };
+        }
+
+
+        public ModuleResults GetResults(IInstanceInfo instanceInfo)
+        {
+            var dbService = instanceInfo.DBService;
+            var results = dbService.ExecuteAndGetTableFromFile("TaskProcessingIssueModule.sql");
+
+            var hasUnprocessedTasks = false;
+            if (results != null && results.Rows.Count > 0)
+            {
+                var row = results.Rows[0];
+
+                foreach (DataColumn column in results.Columns)
+                {
+                    var value = int.Parse(row[column].ToString());
+                    if (value > 0)
+                    {
+                        hasUnprocessedTasks = true;
+                        break;
+                    }
+                }
+            }
+
+            return new ModuleResults
+            {
+                Result = results,
+                Status = hasUnprocessedTasks ? Status.Warning : Status.Good,
+                ResultComment = hasUnprocessedTasks ? "There are unprocessed tasks that should be reviewed." : "All tasks have been processed."
+            };
+        }
+    }
+}

--- a/KInspector.Modules/Modules/General/TaskProcessingIssuesModule.cs
+++ b/KInspector.Modules/Modules/General/TaskProcessingIssuesModule.cs
@@ -12,11 +12,6 @@ namespace Kentico.KInspector.Modules
             {
                 Name = "Task processing issues",
                 SupportedVersions = new[] {
-                    new Version("6.0"),
-                    new Version("7.0"),
-                    new Version("8.0"),
-                    new Version("8.1"),
-                    new Version("8.2"),
                     new Version("9.0")
                 },
                 Comment = @"Checks for possible issues with processing system, workflow, marketing automation, smart search, and web farm tasks.",

--- a/KInspector.Modules/Scripts/TaskProcessingIssueModule.sql
+++ b/KInspector.Modules/Scripts/TaskProcessingIssueModule.sql
@@ -1,0 +1,6 @@
+﻿SELECT
+  (SELECT count(*) FROM [CMS_ScheduledTask] WHERE [TaskDeleteAfterLastRun] = 1 AND [TaskNextRunTime] < DATEADD(hour, -24, GETDATE())) AS SystemTasks,
+  (SELECT count(*) FROM [CMS_WebFarmTask] WHERE TaskCreated < DATEADD(hour, -24, GETDATE())) AS WebFarmTasks,
+  (SELECT count(*) FROM [Integration_Task] WHERE TaskTime < DATEADD(hour, -24, GETDATE())) AS IntegrationTasks,
+  (SELECT count(*) FROM [Staging_Task] WHERE TaskTime < DATEADD(hour, -24, GETDATE())) AS StagingTasks,
+  (SELECT count(*) FROM [CMS_SearchTask] WHERE SearchTaskCreated < DATEADD(hour, -24, GETDATE())) AS SearchTasks


### PR DESCRIPTION
This module checks to see if various task tables have records older than 24hr. still in them. It throws a warning if at least one has some tasks. 