### PR TITLE
Added logic to check for empty string within the IN() query.

### DIFF
--- a/KInspector.Modules/Modules/General/ClassTableValidation.cs
+++ b/KInspector.Modules/Modules/General/ClassTableValidation.cs
@@ -44,6 +44,10 @@ namespace Kentico.KInspector.Modules
             {
                 tablesWithoutClassCount = tablesWithoutClass.Select($"TABLE_NAME not in ({formattedWhitelist})").Count();
             }
+            else
+            {
+                tablesWithoutClassCount = tablesWithoutClass.Select().Count();
+            }
 
             var classesWithoutTable = dbService.ExecuteAndGetTableFromFile("ClassTableValidationClasses.sql");
             classesWithoutTable.TableName = "Kentico Classes without database table";

--- a/KInspector.Modules/Modules/General/ClassTableValidation.cs
+++ b/KInspector.Modules/Modules/General/ClassTableValidation.cs
@@ -38,8 +38,13 @@ namespace Kentico.KInspector.Modules
             var tablesWithoutClass = dbService.ExecuteAndGetTableFromFile("ClassTableValidationTables.sql");
             tablesWithoutClass.TableName = "Database tables without Kentico Class";
             var formattedWhitelist = string.Join(",", GetTableWhitelist(instanceInfo.Version).Select(tn => string.Format("'{0}'", tn)));
-            var tablesWithoutClassCount = tablesWithoutClass.Select($"TABLE_NAME not in ({formattedWhitelist})").Count();
-            
+            var tablesWithoutClassCount = 0;
+
+            if (!string.IsNullOrEmpty(formattedWhitelist) && formattedWhitelist != ",")
+            {
+                tablesWithoutClassCount = tablesWithoutClass.Select($"TABLE_NAME not in ({formattedWhitelist})").Count();
+            }
+
             var classesWithoutTable = dbService.ExecuteAndGetTableFromFile("ClassTableValidationClasses.sql");
             classesWithoutTable.TableName = "Kentico Classes without database table";
             var classesWithoutTableCount = classesWithoutTable.Rows.Count;


### PR DESCRIPTION
When running the class table validation in versions earlier than version 10, it would error out because the string.Join() had an empty string to join which later caused an invalid SQL query.