### PR TITLE
Add a check for CMSEnableCsrfProtection

### DIFF
--- a/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
+++ b/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
@@ -25,6 +25,7 @@ namespace Kentico.KInspector.Modules
 - Custom errors
 - Cookieless authentication
 - Session fixation
+- CSRF protection check 
 - Http only cookies
 - Viewstate (MAC) validation
 - Hash string salt
@@ -147,7 +148,7 @@ namespace Kentico.KInspector.Modules
 
             if (!(bool.TryParse(csrfProtection, out csrfProtectionEnabled) && csrfProtectionEnabled))
             {
-                result.Rows.Add("Session fixation (<add key=\"CMSEnableCsrfProtection\" ...)", csrfProtection, RECOMMENDED_VALUE_TRUE);
+                result.Rows.Add("CSRF protection (<add key=\"CMSEnableCsrfProtection\" ...)", csrfProtection, RECOMMENDED_VALUE_TRUE);
             }
 
             #endregion

--- a/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
+++ b/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
@@ -130,9 +130,28 @@ namespace Kentico.KInspector.Modules
                 result.Rows.Add("Session fixation (<add key=\"CMSRenewSessionAuthChange\" ...)", sessionFixation, RECOMMENDED_VALUE_TRUE);
             }
 
-            # endregion
+            #endregion
 
-            # region "HttpOnlyCookies"
+            #region CSRF Protection
+
+            string csrfProtection = VALUE_NOT_SET;
+
+            try
+            {
+                csrfProtection = configuration.AppSettings.Settings["CMSEnableCsrfProtection"].Value;
+            }
+            catch (Exception e)
+            {
+                //Value not set
+            }
+
+            if (!(bool.TryParse(csrfProtection, out bool csrfProtectionEnabled) && csrfProtectionEnabled)){
+                result.Rows.Add("Session fixation (<add key=\"CMSEnableCsrfProtection\" ...)", csrfProtection, RECOMMENDED_VALUE_TRUE);
+            }
+
+            #endregion
+
+            #region "HttpOnlyCookies"
 
             var httpOnlyCookiesNode = (HttpCookiesSection)configuration.GetSection("system.web/httpCookies");
             bool httpOnlyCookies = httpOnlyCookiesNode.HttpOnlyCookies;

--- a/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
+++ b/KInspector.Modules/Modules/Security/SecurityAppSettingsModule.cs
@@ -135,7 +135,7 @@ namespace Kentico.KInspector.Modules
             #region CSRF Protection
 
             string csrfProtection = VALUE_NOT_SET;
-
+            bool csrfProtectionEnabled = false;
             try
             {
                 csrfProtection = configuration.AppSettings.Settings["CMSEnableCsrfProtection"].Value;
@@ -145,7 +145,8 @@ namespace Kentico.KInspector.Modules
                 //Value not set
             }
 
-            if (!(bool.TryParse(csrfProtection, out bool csrfProtectionEnabled) && csrfProtectionEnabled)){
+            if (!(bool.TryParse(csrfProtection, out csrfProtectionEnabled) && csrfProtectionEnabled))
+            {
                 result.Rows.Add("Session fixation (<add key=\"CMSEnableCsrfProtection\" ...)", csrfProtection, RECOMMENDED_VALUE_TRUE);
             }
 


### PR DESCRIPTION
### Motivation
Adds a check in SecurityAppSettingsModule.cs for CMSEnableCsrfProtection variable in configuration
Fixes #172 

### Checklist

- [x] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [x] Tests are passing
- [x] Docu has been updated (if applicable)
- [x] Temporary settings (e.g. project ID used during development and testing) have been reverted to defaults