### PR TITLE
Fixed missing tables and classes error on Kentico 7

### DIFF
--- a/KInspector.Modules/Modules/General/ClassTableValidation.cs
+++ b/KInspector.Modules/Modules/General/ClassTableValidation.cs
@@ -37,12 +37,12 @@ namespace Kentico.KInspector.Modules
             // Retrieve data
             var tablesWithoutClass = dbService.ExecuteAndGetTableFromFile("ClassTableValidationTables.sql");
             tablesWithoutClass.TableName = "Database tables without Kentico Class";
-            var formattedWhitelist = string.Join(",", GetTableWhitelist(instanceInfo.Version).Select(tn => string.Format("'{0}'", tn)));
+            var formattedTableWhitelist = string.Join(",", GetTableWhitelist(instanceInfo.Version).Select(tn => string.Format("'{0}'", tn)));
             var tablesWithoutClassCount = 0;
 
-            if (!string.IsNullOrEmpty(formattedWhitelist) && formattedWhitelist != ",")
+            if (!string.IsNullOrEmpty(formattedTableWhitelist) && formattedTableWhitelist != ",")
             {
-                tablesWithoutClassCount = tablesWithoutClass.Select($"TABLE_NAME not in ({formattedWhitelist})").Count();
+                tablesWithoutClassCount = tablesWithoutClass.Select($"TABLE_NAME not in ({formattedTableWhitelist})").Count();
             }
             else
             {
@@ -51,7 +51,16 @@ namespace Kentico.KInspector.Modules
 
             var classesWithoutTable = dbService.ExecuteAndGetTableFromFile("ClassTableValidationClasses.sql");
             classesWithoutTable.TableName = "Kentico Classes without database table";
-            var classesWithoutTableCount = classesWithoutTable.Rows.Count;
+            var formattedClassWhitelist = string.Join(",", GetClassWhitelist(instanceInfo.Version).Select(tn => string.Format("'{0}'", tn)));
+            
+            if (!string.IsNullOrEmpty(formattedClassWhitelist) && formattedClassWhitelist != ",")
+            {
+                classesWithoutTableCount = classesWithoutTable.Select($"ClassTableName not in ({formattedClassWhitelist})").Count();
+            }
+            else
+            {
+                classesWithoutTableCount = classesWithoutTable.Select().Count();
+            }
 
             // Merge data into result
             var result = new DataSet("Non-matching Tables-Class entries");
@@ -83,6 +92,28 @@ namespace Kentico.KInspector.Modules
             if (version.Major >= 10)
             {
                whitelist.Add("CI_Migration");
+            }
+            
+            if (version.Major == 7)
+            {
+               whitelist.Add("Analytics_ExitPages");
+               whitelist.Add("Analytics_Index");
+               whitelist.Add("CMS_Session");
+               whitelist.Add("CMS_WebFarmServerTask");
+               whitelist.Add("OM_ScoreContactRule");
+            }
+
+            return whitelist;
+        }
+        
+        private List<string> GetClassWhitelist(Version version)
+        {
+            var whitelist = new List<string>();
+            
+            if (version.Major == 7)
+            {
+               whitelist.Add("COM_SKUOption");
+               whitelist.Add("COM_VariantOption");
             }
 
             return whitelist;

--- a/KInspector.Modules/Modules/General/ClassTableValidation.cs
+++ b/KInspector.Modules/Modules/General/ClassTableValidation.cs
@@ -52,6 +52,7 @@ namespace Kentico.KInspector.Modules
             var classesWithoutTable = dbService.ExecuteAndGetTableFromFile("ClassTableValidationClasses.sql");
             classesWithoutTable.TableName = "Kentico Classes without database table";
             var formattedClassWhitelist = string.Join(",", GetClassWhitelist(instanceInfo.Version).Select(tn => string.Format("'{0}'", tn)));
+            var classesWithoutTableCount = 0;
             
             if (!string.IsNullOrEmpty(formattedClassWhitelist) && formattedClassWhitelist != ",")
             {


### PR DESCRIPTION
Added the tables  Analytics_ExitPages, Analytics_Index, CMS_Session, CMS_WebFarmServerTask and OM_ScoreContactRule to the whiteslist for tables for Kentico 7 and added the classes Ecommerce - SKU option and Ecommerce - Variant option to the whitelist for classes for Kentico 7. This fixes an issue when these are reported missing, as they are apparently "ghosts" of development that were never cleaned up, as noted in the issue #163 Kentico 7 sites report missing tables and classes.

Fixes #163