### PR TITLE
Use enums instead of strings for report results type+status

### DIFF
--- a/KenticoInspector.Core/Constants/ReportResultsStatus.cs
+++ b/KenticoInspector.Core/Constants/ReportResultsStatus.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace KenticoInspector.Core.Models
+namespace KenticoInspector.Core.Constants
 {
     public enum ReportResultsStatus
     {

--- a/KenticoInspector.Core/Constants/ReportResultsType.cs
+++ b/KenticoInspector.Core/Constants/ReportResultsType.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace KenticoInspector.Core.Models
+namespace KenticoInspector.Core.Constants
 {
     public enum ReportResultsType
     {

--- a/KenticoInspector.Core/KenticoInspector.Core.csproj
+++ b/KenticoInspector.Core/KenticoInspector.Core.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/KenticoInspector.Core/Models/ReportResults.cs
+++ b/KenticoInspector.Core/Models/ReportResults.cs
@@ -1,12 +1,17 @@
-﻿using System.Dynamic;
+﻿using KenticoInspector.Core.Constants;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Dynamic;
 
 namespace KenticoInspector.Core.Models
 {
     public class ReportResults
     {
-        public string Status { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReportResultsStatus Status { get; set; }
         public string Summary { get; set; }
-        public string Type { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ReportResultsType Type { get; set; }
         public dynamic Data { get; set; }
 
         public ReportResults()

--- a/KenticoInspector.Reports.Tests/ApplicationRestartAnalysisTests.cs
+++ b/KenticoInspector.Reports.Tests/ApplicationRestartAnalysisTests.cs
@@ -1,3 +1,4 @@
+using KenticoInspector.Core.Constants;
 using KenticoInspector.Core.Models;
 using KenticoInspector.Core.Services.Interfaces;
 using KenticoInspector.Reports.ApplicationRestartAnalysis;
@@ -40,7 +41,7 @@ namespace KenticoInspector.Reports.Tests
 
             // Assert
             Assert.That(results.Data.Rows.Count == 0);
-            Assert.That(results.Status == ReportResultsStatus.Information.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Information);
         }
 
         [Test]
@@ -72,7 +73,7 @@ namespace KenticoInspector.Reports.Tests
 
             // Assert
             Assert.That(results.Data.Rows.Count == 2);
-            Assert.That(results.Status == ReportResultsStatus.Information.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Information);
         }
 
         [Test]
@@ -88,7 +89,7 @@ namespace KenticoInspector.Reports.Tests
             var results = _mockReport.GetResults(_mockInstance.Guid);
 
             // Assert
-            Assert.That(results.Type == ReportResultsType.Table.ToString());
+            Assert.That(results.Type == ReportResultsType.Table);
         }
         private void InitializeCommonMocks(int majorVersion)
         {

--- a/KenticoInspector.Reports.Tests/ClassTableValidationTests.cs
+++ b/KenticoInspector.Reports.Tests/ClassTableValidationTests.cs
@@ -1,3 +1,4 @@
+using KenticoInspector.Core.Constants;
 using KenticoInspector.Core.Models;
 using KenticoInspector.Core.Services.Interfaces;
 using KenticoInspector.Reports.ClassTableValidation;
@@ -47,7 +48,7 @@ namespace KenticoInspector.Reports.Tests
             // Assert
             Assert.That(results.Data.TableResults.Rows.Count == 0);
             Assert.That(results.Data.ClassResults.Rows.Count == 0);
-            Assert.That(results.Status == ReportResultsStatus.Good.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Good);
         }
 
         [Test]
@@ -77,7 +78,7 @@ namespace KenticoInspector.Reports.Tests
             // Assert
             Assert.That(results.Data.TableResults.Rows.Count == 0);
             Assert.That(results.Data.ClassResults.Rows.Count == 1);
-            Assert.That(results.Status == ReportResultsStatus.Error.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Error);
         }
 
         [Test]
@@ -104,7 +105,7 @@ namespace KenticoInspector.Reports.Tests
             // Assert
             Assert.That(results.Data.TableResults.Rows.Count == 1);
             Assert.That(results.Data.ClassResults.Rows.Count == 0);
-            Assert.That(results.Status == ReportResultsStatus.Error.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Error);
         }
 
         private List<ClassWithNoTable> GetCleanClassResults()

--- a/KenticoInspector.Reports.Tests/DatabaseConsistencyCheckTests.cs
+++ b/KenticoInspector.Reports.Tests/DatabaseConsistencyCheckTests.cs
@@ -1,4 +1,5 @@
-﻿using KenticoInspector.Core.Models;
+﻿using KenticoInspector.Core.Constants;
+using KenticoInspector.Core.Models;
 using KenticoInspector.Core.Services.Interfaces;
 using KenticoInspector.Reports.DatabaseConsistencyCheck;
 using KenticoInspector.Reports.Tests.MockHelpers;
@@ -37,7 +38,7 @@ namespace KenticoInspector.Reports.Tests
             var results = _mockReport.GetResults(_mockInstance.Guid);
 
             //Assert
-            Assert.That(results.Status == ReportResultsStatus.Good.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Good);
         }
 
         [Test]
@@ -56,7 +57,7 @@ namespace KenticoInspector.Reports.Tests
             var results = _mockReport.GetResults(_mockInstance.Guid);
 
             //Assert
-            Assert.That(results.Status == ReportResultsStatus.Error.ToString());
+            Assert.That(results.Status == ReportResultsStatus.Error);
         }
 
         private void InitializeCommonMocks(int majorVersion)

--- a/KenticoInspector.Reports/ApplicationRestartAnalysis/Report.cs
+++ b/KenticoInspector.Reports/ApplicationRestartAnalysis/Report.cs
@@ -74,8 +74,8 @@ namespace KenticoInspector.Reports.ApplicationRestartAnalysis
 
             var results = new ReportResults
             {
-                Type = ReportResultsType.Table.ToString(),
-                Status = ReportResultsStatus.Information.ToString(),
+                Type = ReportResultsType.Table,
+                Status = ReportResultsStatus.Information,
                 Summary = $"{totalEventsText} ({totalStartEventsText}, {totalEndEventsText}) {timeSpanText}",
                 Data = data
             };

--- a/KenticoInspector.Reports/ClassTableValidation/Report.cs
+++ b/KenticoInspector.Reports/ClassTableValidation/Report.cs
@@ -71,7 +71,7 @@ namespace KenticoInspector.Reports.ClassTableValidation
 
             var results = new ReportResults
             {
-                Type = ReportResultsType.TableList.ToString()
+                Type = ReportResultsType.TableList
             };
 
             results.Data.TableResults = tableResults;
@@ -80,15 +80,15 @@ namespace KenticoInspector.Reports.ClassTableValidation
             switch (totalErrors)
             {
                 case 0:
-                    results.Status = ReportResultsStatus.Good.ToString();
+                    results.Status = ReportResultsStatus.Good;
                     results.Summary = "No issues found.";
                     break;
                 case 1:
-                    results.Status = ReportResultsStatus.Error.ToString();
+                    results.Status = ReportResultsStatus.Error;
                     results.Summary = "1 issue found.";
                     break;
                 default:
-                    results.Status = ReportResultsStatus.Error.ToString();
+                    results.Status = ReportResultsStatus.Error;
                     results.Summary = $"{totalErrors} issues found.";
                     break;
             }

--- a/KenticoInspector.Reports/DatabaseConsistencyCheck/Report.cs
+++ b/KenticoInspector.Reports/DatabaseConsistencyCheck/Report.cs
@@ -71,8 +71,8 @@ namespace KenticoInspector.Reports.DatabaseConsistencyCheck
             {
                 return new ReportResults
                 {
-                    Type = ReportResultsType.Table.ToString(),
-                    Status = ReportResultsStatus.Error.ToString(),
+                    Type = ReportResultsType.Table,
+                    Status = ReportResultsStatus.Error,
                     Summary = "Check results table for any issues",
                     Data = checkDbResults
                 };
@@ -81,8 +81,8 @@ namespace KenticoInspector.Reports.DatabaseConsistencyCheck
             {
                 return new ReportResults
                 {
-                    Type = ReportResultsType.String.ToString(),
-                    Status = ReportResultsStatus.Good.ToString(),
+                    Type = ReportResultsType.String,
+                    Status = ReportResultsStatus.Good,
                     Summary = "No issues found",
                     Data = string.Empty
                 };


### PR DESCRIPTION
Use enums instead of strings for report results type and report results status. This reduces chance of error and avoid lots of "ToString()" on the enums