### PR TITLE
Issue 308 metadata service loading default language

### DIFF
--- a/KenticoInspector.Core/AbstractReport.cs
+++ b/KenticoInspector.Core/AbstractReport.cs
@@ -7,6 +7,7 @@ namespace KenticoInspector.Core
 {
     public abstract class AbstractReport<T> : IReport, IWithMetadata<T> where T : new()
     {
+        private ReportMetadata<T> metadata;
         protected readonly IReportMetadataService reportMetadataService;
 
         public AbstractReport(IReportMetadataService reportMetadataService)
@@ -27,7 +28,13 @@ namespace KenticoInspector.Core
 
         public abstract IList<string> Tags { get; }
 
-        public ReportMetadata<T> Metadata => reportMetadataService.GetReportMetadata<T>(Codename);
+        public ReportMetadata<T> Metadata
+        {
+            get
+            {
+                return metadata ?? (metadata = reportMetadataService.GetReportMetadata<T>(Codename));
+            }
+        }
 
         public abstract ReportResults GetResults();
 

--- a/KenticoInspector.Core/AbstractReport.cs
+++ b/KenticoInspector.Core/AbstractReport.cs
@@ -7,8 +7,9 @@ namespace KenticoInspector.Core
 {
     public abstract class AbstractReport<T> : IReport, IWithMetadata<T> where T : new()
     {
-        private ReportMetadata<T> metadata;
         protected readonly IReportMetadataService reportMetadataService;
+
+        private ReportMetadata<T> metadata;
 
         public AbstractReport(IReportMetadataService reportMetadataService)
         {
@@ -17,16 +18,9 @@ namespace KenticoInspector.Core
 
         public string Codename => GetCodename(this.GetType());
 
-        public static string GetCodename(Type reportType)
-        {
-            return GetDirectParentNamespace(reportType);
-        }
-
         public abstract IList<Version> CompatibleVersions { get; }
 
         public virtual IList<Version> IncompatibleVersions => new List<Version>();
-
-        public abstract IList<string> Tags { get; }
 
         public ReportMetadata<T> Metadata
         {
@@ -34,6 +28,13 @@ namespace KenticoInspector.Core
             {
                 return metadata ?? (metadata = reportMetadataService.GetReportMetadata<T>(Codename));
             }
+        }
+
+        public abstract IList<string> Tags { get; }
+
+        public static string GetCodename(Type reportType)
+        {
+            return GetDirectParentNamespace(reportType);
         }
 
         public abstract ReportResults GetResults();

--- a/KenticoInspector.Core/Services/Interfaces/IReportMetadataService.cs
+++ b/KenticoInspector.Core/Services/Interfaces/IReportMetadataService.cs
@@ -9,7 +9,5 @@ namespace KenticoInspector.Core.Services.Interfaces
         string CurrentCultureName { get; }
 
         ReportMetadata<T> GetReportMetadata<T>(string reportCodename) where T : new();
-
-        T DeserializeYaml<T>(string path, bool ignoreUnmatchedProperties = false);
     }
 }

--- a/KenticoInspector.Core/Services/Interfaces/IReportMetadataService.cs
+++ b/KenticoInspector.Core/Services/Interfaces/IReportMetadataService.cs
@@ -4,8 +4,12 @@ namespace KenticoInspector.Core.Services.Interfaces
 {
     public interface IReportMetadataService : IService
     {
+        string DefaultCultureName { get; }
+
         string CurrentCultureName { get; }
 
         ReportMetadata<T> GetReportMetadata<T>(string reportCodename) where T : new();
+
+        T DeserializeYaml<T>(string path, bool ignoreUnmatchedProperties = false);
     }
 }

--- a/KenticoInspector.Infrastructure/Services/ReportMetadataService.cs
+++ b/KenticoInspector.Infrastructure/Services/ReportMetadataService.cs
@@ -40,7 +40,7 @@ namespace KenticoInspector.Core.Helpers
             return DeserializeYaml<ReportMetadata<T>>(defaultCultureMetadataPath);
         }
 
-        public T DeserializeYaml<T>(string path, bool ignoreUnmatchedProperties = false)
+        private T DeserializeYaml<T>(string path, bool ignoreUnmatchedProperties = false)
         {
             var deserializerBuilder = new DeserializerBuilder()
                 .WithNamingConvention(new CamelCaseNamingConvention());

--- a/KenticoInspector.Infrastructure/Services/ReportMetadataService.cs
+++ b/KenticoInspector.Infrastructure/Services/ReportMetadataService.cs
@@ -1,7 +1,10 @@
-﻿using KenticoInspector.Core.Models;
-using KenticoInspector.Core.Services.Interfaces;
+﻿using System;
 using System.IO;
 using System.Threading;
+
+using KenticoInspector.Core.Models;
+using KenticoInspector.Core.Services.Interfaces;
+
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
@@ -9,22 +12,100 @@ namespace KenticoInspector.Core.Helpers
 {
     public class ReportMetadataService : IReportMetadataService
     {
+        public string DefaultCultureName => "en-US";
+
         public string CurrentCultureName => Thread.CurrentThread.CurrentCulture.Name;
 
         public ReportMetadata<T> GetReportMetadata<T>(string reportCodename) where T : new()
         {
-            var yamlPath = $"{DirectoryHelper.GetExecutingDirectory()}\\{reportCodename}\\Metadata\\{CurrentCultureName}.yaml";
-            return DeserializeYaml<ReportMetadata<T>>(yamlPath);
+            var metadataDirectory = $"{DirectoryHelper.GetExecutingDirectory()}\\{reportCodename}\\Metadata\\";
+
+            var defaultCultureMetadataPath = $"{metadataDirectory}{DefaultCultureName}.yaml";
+
+            var currentCultureMetadataPath = $"{metadataDirectory}{CurrentCultureName}.yaml";
+
+            var currentCultureIsDefaultCulture = DefaultCultureName == CurrentCultureName;
+
+            var currentCultureMetadataPathExists = File.Exists(currentCultureMetadataPath);
+
+            if (!currentCultureIsDefaultCulture && currentCultureMetadataPathExists)
+            {
+                var defaultCultureMetadata = DeserializeYaml<ReportMetadata<T>>(defaultCultureMetadataPath);
+
+                var currentCultureMetadata = DeserializeYaml<ReportMetadata<T>>(currentCultureMetadataPath, true);
+
+                return GetMergedMetadata(defaultCultureMetadata, currentCultureMetadata);
+            }
+
+            return DeserializeYaml<ReportMetadata<T>>(defaultCultureMetadataPath);
         }
 
-        public T DeserializeYaml<T>(string path)
+        public T DeserializeYaml<T>(string path, bool ignoreUnmatchedProperties = false)
         {
-            var deserializer = new DeserializerBuilder()
-                .WithNamingConvention(new CamelCaseNamingConvention())
+            var deserializerBuilder = new DeserializerBuilder()
+                .WithNamingConvention(new CamelCaseNamingConvention());
+
+            if (ignoreUnmatchedProperties)
+            {
+                deserializerBuilder
+                    .IgnoreUnmatchedProperties();
+            }
+
+            var deserializer = deserializerBuilder
                 .Build();
 
             var yamlFile = File.ReadAllText(path);
+
             return deserializer.Deserialize<T>(yamlFile);
+        }
+
+        private ReportMetadata<T> GetMergedMetadata<T>(ReportMetadata<T> defaultMetadata, ReportMetadata<T> overrideMetadata) where T : new()
+        {
+            var mergedMetadata = new ReportMetadata<T>
+            {
+                Details = new ReportDetails(),
+                Terms = new T()
+            };
+
+            mergedMetadata.Details.Name = overrideMetadata.Details?.Name ?? defaultMetadata.Details.Name;
+            mergedMetadata.Details.ShortDescription = overrideMetadata.Details?.ShortDescription ?? defaultMetadata.Details.ShortDescription;
+            mergedMetadata.Details.LongDescription = overrideMetadata.Details?.LongDescription ?? defaultMetadata.Details.LongDescription;
+
+            RecursivelySetPropertyValues(typeof(T), defaultMetadata.Terms, overrideMetadata.Terms, mergedMetadata.Terms);
+
+            return mergedMetadata;
+        }
+
+        private static void RecursivelySetPropertyValues(Type objectType, object defaultObject, object overrideObject, object targetObject)
+        {
+            var objectTypeProperties = objectType.GetProperties();
+
+            foreach (var objectTypeProperty in objectTypeProperties)
+            {
+                var objectTypePropertyType = objectTypeProperty.PropertyType;
+
+                var defaultObjectPropertyValue = objectTypeProperty.GetValue(defaultObject);
+
+                object overrideObjectPropertyValue = null;
+
+                if (overrideObject != null)
+                {
+                    overrideObjectPropertyValue = objectTypeProperty.GetValue(overrideObject);
+                }
+
+                if (objectTypePropertyType.Namespace == objectType.Namespace)
+                {
+                    var targetObjectPropertyValue = Activator.CreateInstance(objectTypePropertyType);
+
+                    objectTypeProperty.SetValue(targetObject, targetObjectPropertyValue);
+
+                    RecursivelySetPropertyValues(objectTypePropertyType, defaultObjectPropertyValue, overrideObjectPropertyValue, targetObjectPropertyValue);
+                }
+                else
+                {
+                    objectTypeProperty.SetValue(targetObject, overrideObjectPropertyValue ?? defaultObjectPropertyValue);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation

Fixes #308

### Checklist

- [ ] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [ ] Tests are passing
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

This should do the following:
- Load default metadata YAML when the current culture metadata YAML does not exist
- Load non-default (non-en-US) YAML metadata, merge if it is partial, as long as it matches the structure of the model.