### PR TITLE
Support for XbK 30/31

### DIFF
--- a/Directory.build.props
+++ b/Directory.build.props
@@ -5,7 +5,7 @@
 		<Copyright>Copyright © $(Company) $([System.DateTime]::Now.Year)</Copyright>
 		<Trademark>$(Company)™</Trademark>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<VersionPrefix>5.1.0</VersionPrefix>
+		<VersionPrefix>5.2.0</VersionPrefix>
 		<LangVersion>10.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>

--- a/src/KInspector.Actions/DisableSmtpServers/Action.cs
+++ b/src/KInspector.Actions/DisableSmtpServers/Action.cs
@@ -13,6 +13,8 @@ namespace KInspector.Actions.DisableSmtpServers
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string> {
             ModuleTags.Configuration,
             ModuleTags.Emails

--- a/src/KInspector.Actions/DisableStagingServers/Action.cs
+++ b/src/KInspector.Actions/DisableStagingServers/Action.cs
@@ -13,6 +13,8 @@ namespace KInspector.Actions.DisableStagingServers
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string> {
             ModuleTags.Configuration,
             ModuleTags.Staging

--- a/src/KInspector.Actions/DisableWebFarmServers/Action.cs
+++ b/src/KInspector.Actions/DisableWebFarmServers/Action.cs
@@ -11,7 +11,7 @@ namespace KInspector.Actions.DisableWebFarmServers
     {
         private readonly IDatabaseService databaseService;
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("12", "13");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string> {
             ModuleTags.Configuration,

--- a/src/KInspector.Actions/ResetCmsUserLogin/Action.cs
+++ b/src/KInspector.Actions/ResetCmsUserLogin/Action.cs
@@ -13,6 +13,8 @@ namespace KInspector.Actions.ResetCmsUserLogin
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string> {
             ModuleTags.Reset,
             ModuleTags.User

--- a/src/KInspector.Actions/StopRunningSites/Action.cs
+++ b/src/KInspector.Actions/StopRunningSites/Action.cs
@@ -13,6 +13,8 @@ namespace KInspector.Actions.StopRunningSites
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string> {
             ModuleTags.Site,
             ModuleTags.Configuration

--- a/src/KInspector.Blazor/package-lock.json
+++ b/src/KInspector.Blazor/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "KInspector.Blazor",
+  "name": "kinspector.blazor",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/KInspector.Core/Helpers/VersionHelper.cs
+++ b/src/KInspector.Core/Helpers/VersionHelper.cs
@@ -11,6 +11,14 @@ namespace KInspector.Core.Helpers
                 .ToList();
         }
 
+        public static IList<Version> GetVersionsGreaterThan(int majorVersion)
+        {
+            return Enumerable.Range(majorVersion + 1, majorVersion + 100)
+                .Select(v => v.ToString())
+                .Select(GetVersionFromShortString)
+                .ToList();
+        }
+
         public static Version GetVersionFromShortString(string version)
         {
             var expandedVersionString = ExpandVersionString(version);

--- a/src/KInspector.Reports/ApplicationRestartAnalysis/Report.cs
+++ b/src/KInspector.Reports/ApplicationRestartAnalysis/Report.cs
@@ -12,7 +12,7 @@ namespace KInspector.Reports.ApplicationRestartAnalysis
     {
         private readonly IDatabaseService databaseService;
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string>
         {

--- a/src/KInspector.Reports/ClassTableValidation/Report.cs
+++ b/src/KInspector.Reports/ClassTableValidation/Report.cs
@@ -25,7 +25,7 @@ namespace KInspector.Reports.ClassTableValidation
             this.configService = configService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string> {
             ModuleTags.Health,
@@ -35,8 +35,10 @@ namespace KInspector.Reports.ClassTableValidation
         {
             var instance = configService.GetCurrentInstance();
             var instanceDetails = instanceService.GetInstanceDetails(instance);
+            bool isXbK = instanceDetails?.AdministrationDatabaseVersion?.Major > 13;
+
             var tablesWithMissingClass = await GetResultsForTables(instanceDetails);
-            var classesWithMissingTable = await GetResultsForClasses();
+            var classesWithMissingTable = await GetResultsForClasses(isXbK);
 
             return CompileResults(tablesWithMissingClass, classesWithMissingTable);
         }
@@ -79,7 +81,9 @@ namespace KInspector.Reports.ClassTableValidation
             return results;
         }
 
-        private Task<IEnumerable<ClassWithNoTable>> GetResultsForClasses() => databaseService.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTable);
+        private Task<IEnumerable<ClassWithNoTable>> GetResultsForClasses(bool isXbK) => isXbK ?
+            databaseService.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTableXbK)
+            : databaseService.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTable);
 
         private async Task<IEnumerable<TableWithNoClass>> GetResultsForTables(InstanceDetails instanceDetails)
         {
@@ -101,6 +105,10 @@ namespace KInspector.Reports.ClassTableValidation
             if (version?.Major >= 10)
             {
                 whitelist.Add("CI_Migration");
+            }
+            if (version?.Major >= 30)
+            {
+                whitelist.Add("CD_Migration");
             }
 
             return whitelist;

--- a/src/KInspector.Reports/ClassTableValidation/Scripts.cs
+++ b/src/KInspector.Reports/ClassTableValidation/Scripts.cs
@@ -6,6 +6,8 @@
 
         public static string ClassesWithNoTable => $"{BaseDirectory}/{nameof(ClassesWithNoTable)}.sql";
 
+        public static string ClassesWithNoTableXbK => $"{BaseDirectory}/{nameof(ClassesWithNoTableXbK)}.sql";
+
         public static string TablesWithNoClass => $"{BaseDirectory}/{nameof(TablesWithNoClass)}.sql";
     }
 }

--- a/src/KInspector.Reports/ClassTableValidation/Scripts/ClassesWithNoTableXbK.sql
+++ b/src/KInspector.Reports/ClassTableValidation/Scripts/ClassesWithNoTableXbK.sql
@@ -1,0 +1,7 @@
+﻿-- Classes with missing database tables.
+SELECT ClassDisplayName, ClassName, ClassTableName FROM CMS_Class
+	WHERE
+		ClassContentTypeType IS NULL AND
+		ClassTableName NOT IN (SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES)
+	ORDER BY
+		ClassDisplayName, ClassName, ClassTableName

--- a/src/KInspector.Reports/ColumnFieldValidation/Report.cs
+++ b/src/KInspector.Reports/ColumnFieldValidation/Report.cs
@@ -23,7 +23,7 @@ namespace KInspector.Reports.ColumnFieldValidation
             this.databaseService = databaseService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string>
         {
@@ -190,6 +190,9 @@ namespace KInspector.Reports.ColumnFieldValidation
                     break;
 
                 case "System.Guid, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089":
+                case "System.Guid, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e":
+                case "System.Guid, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e":
+                case "System.Guid, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e":
                     type = "uniqueidentifier";
                     break;
             }

--- a/src/KInspector.Reports/ContentTreeConsistencyAnalysis/Report.cs
+++ b/src/KInspector.Reports/ContentTreeConsistencyAnalysis/Report.cs
@@ -20,6 +20,8 @@ namespace KInspector.Reports.ContentTreeConsistencyAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string>()
         {
             ModuleTags.Health,

--- a/src/KInspector.Reports/DatabaseConsistencyCheck/Report.cs
+++ b/src/KInspector.Reports/DatabaseConsistencyCheck/Report.cs
@@ -18,7 +18,7 @@ namespace KInspector.Reports.DatabaseConsistencyCheck
             this.databaseService = databaseService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string> {
             ModuleTags.Health

--- a/src/KInspector.Reports/DatabaseTableSizeAnalysis/Report.cs
+++ b/src/KInspector.Reports/DatabaseTableSizeAnalysis/Report.cs
@@ -16,7 +16,7 @@ namespace KInspector.Reports.DatabaseTableSizeAnalysis
             this.databaseService = databaseService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string> {
             ModuleTags.Health

--- a/src/KInspector.Reports/DebugConfigurationAnalysis/Report.cs
+++ b/src/KInspector.Reports/DebugConfigurationAnalysis/Report.cs
@@ -28,6 +28,8 @@ namespace KInspector.Reports.DebugConfigurationAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string> {
            ModuleTags.Health
         };

--- a/src/KInspector.Reports/KInspector.Reports.csproj
+++ b/src/KInspector.Reports/KInspector.Reports.csproj
@@ -14,6 +14,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="ClassTableValidation\Scripts\ClassesWithNoTableXbK.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="OnlineMarketingMacroAnalysis\Scripts\GetManualScoreRuleMacroConditions.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -24,6 +27,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="PageTypeFieldAnalysis\Metadata\en-US.yaml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="PageTypeFieldAnalysis\Scripts\GetCmsPageTypeFieldsXbK.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="PageTypeFieldAnalysis\Scripts\GetCmsPageTypeFields.sql">
@@ -45,6 +51,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="SecuritySettingsAnalysis\Scripts\GetSecurityCmsSettings.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TaskProcessingAnalysis\Scripts\GetCountOfUnprocessedScheduledTasksXbK.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="UnusedPageTypeSummary\Scripts\GetUnusedPageTypesXbK.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Update="UserPasswordAnalysis\Metadata\en-US.yaml">

--- a/src/KInspector.Reports/OnlineMarketingMacroAnalysis/Report.cs
+++ b/src/KInspector.Reports/OnlineMarketingMacroAnalysis/Report.cs
@@ -18,6 +18,8 @@ namespace KInspector.Reports.OnlineMarketingMacroAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string> {
             ModuleTags.Performance,
             ModuleTags.OnlineMarketing

--- a/src/KInspector.Reports/PageTypeAssignmentAnalysis/Report.cs
+++ b/src/KInspector.Reports/PageTypeAssignmentAnalysis/Report.cs
@@ -18,6 +18,8 @@ namespace KInspector.Reports.PageTypeAssignmentAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string>
         {
             ModuleTags.Health,

--- a/src/KInspector.Reports/PageTypeFieldAnalysis/Metadata/en-US.yaml
+++ b/src/KInspector.Reports/PageTypeFieldAnalysis/Metadata/en-US.yaml
@@ -5,6 +5,7 @@
     This report shows fields with duplicated names, their SQL data types, and their associated page types.
     
     Two or more page types with fields with the same name, but different data types, cause several issues within kentico, not limited to the following:
+    - Content synchronization
     - Exporting/importing a site 
     - Working with web parts or widgets that list more than one page type
     

--- a/src/KInspector.Reports/PageTypeFieldAnalysis/Report.cs
+++ b/src/KInspector.Reports/PageTypeFieldAnalysis/Report.cs
@@ -9,15 +9,23 @@ namespace KInspector.Reports.PageTypeFieldAnalysis
 {
     public class Report : AbstractReport<Terms>
     {
+        private readonly IConfigService configService;
+        private readonly IInstanceService instanceService;
         private readonly IDatabaseService databaseService;
 
-        public Report(IDatabaseService databaseService, IModuleMetadataService moduleMetadataService) 
-            : base(moduleMetadataService)
+        public Report(
+            IDatabaseService databaseService,
+            IInstanceService instanceService,
+            IConfigService configService,
+            IModuleMetadataService moduleMetadataService
+            ) : base(moduleMetadataService)
         {
             this.databaseService = databaseService;
+            this.instanceService = instanceService;
+            this.configService = configService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string>
         {
@@ -27,7 +35,12 @@ namespace KInspector.Reports.PageTypeFieldAnalysis
 
         public async override Task<ModuleResults> GetResults()
         {
-            var pagetypeFields = await databaseService.ExecuteSqlFromFile<CmsPageTypeField>(Scripts.GetCmsPageTypeFields);
+            var instance = configService.GetCurrentInstance();
+            var instanceDetails = instanceService.GetInstanceDetails(instance);
+            bool isXbK = instanceDetails?.AdministrationDatabaseVersion?.Major > 13;
+            string script = isXbK ? Scripts.GetCmsPageTypeFieldsXbK : Scripts.GetCmsPageTypeFields;
+
+            var pagetypeFields = await databaseService.ExecuteSqlFromFile<CmsPageTypeField>(script);
             var fieldsWithMismatchedTypes = CheckForMismatchedTypes(pagetypeFields);
 
             return CompileResults(fieldsWithMismatchedTypes);

--- a/src/KInspector.Reports/PageTypeFieldAnalysis/Scripts.cs
+++ b/src/KInspector.Reports/PageTypeFieldAnalysis/Scripts.cs
@@ -5,5 +5,7 @@
         public static string BaseDirectory => $"{nameof(PageTypeFieldAnalysis)}/Scripts";
 
         public static string GetCmsPageTypeFields => $"{BaseDirectory}/{nameof(GetCmsPageTypeFields)}.sql";
+
+        public static string GetCmsPageTypeFieldsXbK => $"{BaseDirectory}/{nameof(GetCmsPageTypeFieldsXbK)}.sql";
     }
 }

--- a/src/KInspector.Reports/PageTypeFieldAnalysis/Scripts/GetCmsPageTypeFieldsXbK.sql
+++ b/src/KInspector.Reports/PageTypeFieldAnalysis/Scripts/GetCmsPageTypeFieldsXbK.sql
@@ -1,0 +1,10 @@
+﻿SELECT
+	ClassName as PageTypeCodeName,
+	COLUMN_NAME as FieldName,
+	DATA_TYPE as FieldDataType
+FROM
+	INFORMATION_SCHEMA.COLUMNS
+INNER JOIN CMS_Class ON
+	ClassTableName = TABLE_NAME
+WHERE 
+	ClassContentTypeType IS NOT NULL

--- a/src/KInspector.Reports/RobotsTxtConfigurationSummary/Report.cs
+++ b/src/KInspector.Reports/RobotsTxtConfigurationSummary/Report.cs
@@ -32,7 +32,7 @@ namespace KInspector.Reports.RobotsTxtConfigurationSummary
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12");
 
-        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionList("13");
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
 
         public override IList<string> Tags => new List<string>
         {

--- a/src/KInspector.Reports/RobotsTxtConfigurationSummary/Report.cs
+++ b/src/KInspector.Reports/RobotsTxtConfigurationSummary/Report.cs
@@ -32,7 +32,7 @@ namespace KInspector.Reports.RobotsTxtConfigurationSummary
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12");
 
-        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(12);
 
         public override IList<string> Tags => new List<string>
         {

--- a/src/KInspector.Reports/SecuritySettingsAnalysis/Report.cs
+++ b/src/KInspector.Reports/SecuritySettingsAnalysis/Report.cs
@@ -22,6 +22,8 @@ namespace KInspector.Reports.SecuritySettingsAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string>
         {
             ModuleTags.Security,

--- a/src/KInspector.Reports/TaskProcessingAnalysis/Metadata/en-US.yaml
+++ b/src/KInspector.Reports/TaskProcessingAnalysis/Metadata/en-US.yaml
@@ -2,8 +2,8 @@
   name: Task processing analysis
   shortDescription: Checks system queues for tasks that appear stuck for more than 24 hours.
   longDescription: |
-    The following queues are reviewed for stuck tasks:
-      * Scheduled tasks (ignores recurring)
+    The following queues are reviewed for stuck tasks, depending on the version you are using:
+      * Single-run Scheduled tasks
       * Web Farm tasks
       * Integration Bus tasks
       * Staging tasks

--- a/src/KInspector.Reports/TaskProcessingAnalysis/Report.cs
+++ b/src/KInspector.Reports/TaskProcessingAnalysis/Report.cs
@@ -9,14 +9,23 @@ namespace KInspector.Reports.TaskProcessingAnalysis
 {
     public class Report : AbstractReport<Terms>
     {
+        private readonly IConfigService configService;
+        private readonly IInstanceService instanceService;
         private readonly IDatabaseService databaseService;
 
-        public Report(IDatabaseService databaseService, IModuleMetadataService moduleMetadataService) : base(moduleMetadataService)
+        public Report(
+            IDatabaseService databaseService,
+            IInstanceService instanceService,
+            IConfigService configService,
+            IModuleMetadataService moduleMetadataService
+            ) : base(moduleMetadataService)
         {
             this.databaseService = databaseService;
+            this.instanceService = instanceService;
+            this.configService = configService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string> {
            ModuleTags.Health
@@ -24,20 +33,34 @@ namespace KInspector.Reports.TaskProcessingAnalysis
 
         public async override Task<ModuleResults> GetResults()
         {
-            var unprocessedIntegrationBusTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedIntegrationBusTasks);
-            var unprocessedScheduledTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedScheduledTasks);
-            var unprocessedSearchTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedSearchTasks);
-            var unprocessedStagingTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedStagingTasks);
             var unprocessedWebFarmTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedWebFarmTasks);
-
             var rawResults = new Dictionary<TaskType, int>
             {
-                { TaskType.IntegrationBusTask, unprocessedIntegrationBusTasks },
-                { TaskType.ScheduledTask, unprocessedScheduledTasks },
-                { TaskType.SearchTask, unprocessedSearchTasks },
-                { TaskType.StagingTask, unprocessedStagingTasks },
                 { TaskType.WebFarmTask, unprocessedWebFarmTasks }
             };
+
+            var instance = configService.GetCurrentInstance();
+            var instanceDetails = instanceService.GetInstanceDetails(instance);
+            bool isKentico13OrOlder = instanceDetails?.AdministrationDatabaseVersion?.Major <= 13;
+            if (isKentico13OrOlder)
+            {
+                var unprocessedIntegrationBusTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedIntegrationBusTasks);
+                rawResults.Add(TaskType.IntegrationBusTask, unprocessedIntegrationBusTasks);
+
+                var unprocessedSearchTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedSearchTasks);
+                rawResults.Add(TaskType.SearchTask, unprocessedSearchTasks);
+
+                var unprocessedStagingTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedStagingTasks);
+                rawResults.Add(TaskType.StagingTask, unprocessedStagingTasks);
+
+                var unprocessedScheduledTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedScheduledTasks);
+                rawResults.Add(TaskType.ScheduledTask, unprocessedScheduledTasks);
+            }
+            else
+            {
+                var unprocessedScheduledTasks = await databaseService.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedScheduledTasksXbK);
+                rawResults.Add(TaskType.ScheduledTask, unprocessedScheduledTasks);
+            }
 
             return CompileResults(rawResults);
         }

--- a/src/KInspector.Reports/TaskProcessingAnalysis/Scripts.cs
+++ b/src/KInspector.Reports/TaskProcessingAnalysis/Scripts.cs
@@ -8,6 +8,8 @@
 
         public static string GetCountOfUnprocessedScheduledTasks => $"{BaseDirectory}/{nameof(GetCountOfUnprocessedScheduledTasks)}.sql";
 
+        public static string GetCountOfUnprocessedScheduledTasksXbK => $"{BaseDirectory}/{nameof(GetCountOfUnprocessedScheduledTasksXbK)}.sql";
+
         public static string GetCountOfUnprocessedSearchTasks => $"{BaseDirectory}/{nameof(GetCountOfUnprocessedSearchTasks)}.sql";
 
         public static string GetCountOfUnprocessedStagingTasks => $"{BaseDirectory}/{nameof(GetCountOfUnprocessedStagingTasks)}.sql";

--- a/src/KInspector.Reports/TaskProcessingAnalysis/Scripts/GetCountOfUnprocessedScheduledTasksXbK.sql
+++ b/src/KInspector.Reports/TaskProcessingAnalysis/Scripts/GetCountOfUnprocessedScheduledTasksXbK.sql
@@ -1,0 +1,3 @@
+﻿SELECT COUNT(*) FROM CMS_ScheduledTaskConfiguration
+	WHERE ScheduledTaskConfigurationDeleteAfterLastRun = 1 
+	AND ScheduledTaskConfigurationNextRunTime < DATEADD(hour, -24, GETDATE())

--- a/src/KInspector.Reports/TemplateLayoutAnalysis/Report.cs
+++ b/src/KInspector.Reports/TemplateLayoutAnalysis/Report.cs
@@ -18,6 +18,8 @@ namespace KInspector.Reports.TemplateLayoutAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string>
         {
             ModuleTags.Information,

--- a/src/KInspector.Reports/TransformationSecurityAnalysis/Report.cs
+++ b/src/KInspector.Reports/TransformationSecurityAnalysis/Report.cs
@@ -32,7 +32,7 @@ namespace KInspector.Reports.TransformationSecurityAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12");
 
-        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionList("13");
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(12);
 
         public override IList<string> Tags => new List<string>
         {

--- a/src/KInspector.Reports/UnusedPageTypeSummary/Metadata/en-US.yaml
+++ b/src/KInspector.Reports/UnusedPageTypeSummary/Metadata/en-US.yaml
@@ -3,6 +3,7 @@
   shortDescription: Checks for unused pages types.
   longDescription: |
     This report checks for page types that are not in use by any page on any site.
+    For Xperience by Kentico, this report checks content types used on Website channels and the Content Hub.
 terms:
   countUnusedPageType: <count> unused page <count|type|types>.
   unusedPageTypes: Unused page types

--- a/src/KInspector.Reports/UnusedPageTypeSummary/Report.cs
+++ b/src/KInspector.Reports/UnusedPageTypeSummary/Report.cs
@@ -10,13 +10,22 @@ namespace KInspector.Reports.UnusedPageTypeSummary
     public class Report : AbstractReport<Terms>
     {
         private readonly IDatabaseService databaseService;
+        private readonly IInstanceService instanceService;
+        private readonly IConfigService configService;
 
-        public Report(IDatabaseService databaseService, IModuleMetadataService moduleMetadataService) : base(moduleMetadataService)
+        public Report(
+            IDatabaseService databaseService,
+            IInstanceService instanceService,
+            IModuleMetadataService moduleMetadataService,
+            IConfigService configService
+            ) : base(moduleMetadataService)
         {
             this.databaseService = databaseService;
+            this.instanceService = instanceService;
+            this.configService = configService;
         }
 
-        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
+        public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13", "30", "31");
 
         public override IList<string> Tags => new List<string>
         {
@@ -25,7 +34,12 @@ namespace KInspector.Reports.UnusedPageTypeSummary
 
         public async override Task<ModuleResults> GetResults()
         {
-            var unusedPageTypes = await databaseService.ExecuteSqlFromFile<PageType>(Scripts.GetUnusedPageTypes);
+            var instance = configService.GetCurrentInstance();
+            var instanceDetails = instanceService.GetInstanceDetails(instance);
+            bool isXbK = instanceDetails?.AdministrationDatabaseVersion?.Major > 13;
+
+            var script = isXbK ? Scripts.GetUnusedPageTypesXbK : Scripts.GetUnusedPageTypes;
+            var unusedPageTypes = await databaseService.ExecuteSqlFromFile<PageType>(script);
             var countOfUnusedPageTypes = unusedPageTypes.Count();
 
             var results = new ModuleResults

--- a/src/KInspector.Reports/UnusedPageTypeSummary/Scripts.cs
+++ b/src/KInspector.Reports/UnusedPageTypeSummary/Scripts.cs
@@ -4,7 +4,8 @@
     {
         public static string BaseDirectory => $"{nameof(UnusedPageTypeSummary)}/Scripts";
 
-
         public static string GetUnusedPageTypes => $"{BaseDirectory}/{nameof(GetUnusedPageTypes)}.sql";
+
+        public static string GetUnusedPageTypesXbK => $"{BaseDirectory}/{nameof(GetUnusedPageTypesXbK)}.sql";
     }
 }

--- a/src/KInspector.Reports/UnusedPageTypeSummary/Scripts/GetUnusedPageTypesXbK.sql
+++ b/src/KInspector.Reports/UnusedPageTypeSummary/Scripts/GetUnusedPageTypesXbK.sql
@@ -1,0 +1,5 @@
+﻿SELECT ClassDisplayName, ClassName
+  FROM CMS_Class
+  WHERE
+    ClassContentTypeType IN ('Website', 'Reusable') AND
+    ClassID not in (SELECT DISTINCT ContentItemContentTypeID FROM CMS_ContentItem)

--- a/src/KInspector.Reports/UserPasswordAnalysis/Report.cs
+++ b/src/KInspector.Reports/UserPasswordAnalysis/Report.cs
@@ -21,6 +21,8 @@ namespace KInspector.Reports.UserPasswordAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12", "13");
 
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(13);
+
         public override IList<string> Tags => new List<string>
         {
             ModuleTags.Security,

--- a/src/KInspector.Reports/WebPartPerformanceAnalysis/Report.cs
+++ b/src/KInspector.Reports/WebPartPerformanceAnalysis/Report.cs
@@ -20,7 +20,7 @@ namespace KInspector.Reports.WebPartPerformanceAnalysis
 
         public override IList<Version> CompatibleVersions => VersionHelper.GetVersionList("10", "11", "12");
 
-        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionList("13");
+        public override IList<Version> IncompatibleVersions => VersionHelper.GetVersionsGreaterThan(12);
 
         public override IList<string> Tags => new List<string> {
             ModuleTags.PortalEngine,

--- a/test/KInspector.Modules.Tests/Actions/DisableWebFarmServersTests.cs
+++ b/test/KInspector.Modules.Tests/Actions/DisableWebFarmServersTests.cs
@@ -16,6 +16,8 @@ namespace KInspector.Tests.Common.Actions
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class DisableWebFarmServersTests : AbstractActionTest<Action, Terms, Options>
     {
         private readonly Action _mockAction;

--- a/test/KInspector.Modules.Tests/Reports/ApplicationRestartAnalysisTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/ApplicationRestartAnalysisTests.cs
@@ -11,6 +11,8 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class ApplicationRestartAnalysisTests : AbstractModuleTest<Report, Terms>
     {
         private readonly Report _mockReport;

--- a/test/KInspector.Modules.Tests/Reports/ClassTableValidationTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/ClassTableValidationTests.cs
@@ -34,6 +34,10 @@ namespace KInspector.Tests.Common.Reports
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTable))
                 .Returns(Task.FromResult(classResults));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTableXbK))
+                .Returns(Task.FromResult(classResults));
+
 
             // Act
             var results = await _mockReport.GetResults();
@@ -62,6 +66,9 @@ namespace KInspector.Tests.Common.Reports
 
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTable))
+                .Returns(Task.FromResult(classResults.AsEnumerable()));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTableXbK))
                 .Returns(Task.FromResult(classResults.AsEnumerable()));
 
             // Act
@@ -94,6 +101,9 @@ namespace KInspector.Tests.Common.Reports
             var classResults = GetCleanClassResults();
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTable))
+                .Returns(Task.FromResult(classResults));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFile<ClassWithNoTable>(Scripts.ClassesWithNoTableXbK))
                 .Returns(Task.FromResult(classResults));
 
             // Act

--- a/test/KInspector.Modules.Tests/Reports/ClassTableValidationTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/ClassTableValidationTests.cs
@@ -10,6 +10,8 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class ClassTableValidationTests : AbstractModuleTest<Report, Terms>
     {
         private readonly Report _mockReport;

--- a/test/KInspector.Modules.Tests/Reports/ColumnFieldValidationTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/ColumnFieldValidationTests.cs
@@ -13,6 +13,8 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class ColumnFieldValidationTests : AbstractModuleTest<Report, Terms>
     {
         private readonly Report mockReport;

--- a/test/KInspector.Modules.Tests/Reports/DatabaseConsistencyCheckTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/DatabaseConsistencyCheckTests.cs
@@ -12,6 +12,8 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class DatabaseConsistencyCheckTests : AbstractModuleTest<Report, Terms>
     {
         private readonly Report _mockReport;

--- a/test/KInspector.Modules.Tests/Reports/DatabaseTableSizeAnalysisTest.cs
+++ b/test/KInspector.Modules.Tests/Reports/DatabaseTableSizeAnalysisTest.cs
@@ -10,6 +10,8 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class DatabaseTableSizeAnalysisTest : AbstractModuleTest<Report, Terms>
     {
         private readonly Report _mockReport;

--- a/test/KInspector.Modules.Tests/Reports/PageTypeFieldAnalysisTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/PageTypeFieldAnalysisTests.cs
@@ -1,6 +1,7 @@
 ﻿using KInspector.Core.Constants;
-using KInspector.Reports.PageTypeFieldAnalysis.Models;
 using KInspector.Reports.PageTypeFieldAnalysis;
+using KInspector.Reports.PageTypeFieldAnalysis.Models;
+using KInspector.Tests.Common.Helpers;
 
 using NUnit.Framework;
 
@@ -10,6 +11,8 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class PageTypeFieldAnalysisTests : AbstractModuleTest<Report, Terms>
     {
         private readonly Report mockReport;
@@ -34,7 +37,12 @@ namespace KInspector.Tests.Common.Reports
 
         public PageTypeFieldAnalysisTests(int majorVersion) : base(majorVersion)
         {
-            mockReport = new Report(_mockDatabaseService.Object, _mockModuleMetadataService.Object);
+            var mockInstance = MockInstances.Get(majorVersion) ?? throw new InvalidOperationException($"No instance found with major version {majorVersion}.");
+            var mockInstanceDetails = MockInstanceDetails.Get(majorVersion) ?? throw new InvalidOperationException($"No instance details found with major version {majorVersion}.");
+            var mockInstanceService = MockInstanceServiceHelper.SetupInstanceService(mockInstance, mockInstanceDetails);
+            var mockConfigService = MockConfigServiceHelper.SetupMockConfigService(mockInstance);
+
+            mockReport = new Report(_mockDatabaseService.Object, mockInstanceService.Object, mockConfigService.Object, _mockModuleMetadataService.Object);
         }
 
         [TestCase(Category = "Matching fields have save data types", TestName = "Page type fields with matching names and data types produce a good result")]

--- a/test/KInspector.Modules.Tests/Reports/PageTypeFieldAnalysisTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/PageTypeFieldAnalysisTests.cs
@@ -52,6 +52,9 @@ namespace KInspector.Tests.Common.Reports
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFile<CmsPageTypeField>(Scripts.GetCmsPageTypeFields))
                 .Returns(Task.FromResult(CmsPageTypeFieldsWithoutIssues));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFile<CmsPageTypeField>(Scripts.GetCmsPageTypeFieldsXbK))
+                .Returns(Task.FromResult(CmsPageTypeFieldsWithoutIssues));
 
             // Act
             var results = await mockReport.GetResults();
@@ -66,6 +69,9 @@ namespace KInspector.Tests.Common.Reports
             // Arrange
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFile<CmsPageTypeField>(Scripts.GetCmsPageTypeFields))
+                .Returns(Task.FromResult(CmsPageTypeFieldsWithIdenticalNamesAndDifferentDataTypes));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFile<CmsPageTypeField>(Scripts.GetCmsPageTypeFieldsXbK))
                 .Returns(Task.FromResult(CmsPageTypeFieldsWithIdenticalNamesAndDifferentDataTypes));
 
             // Act

--- a/test/KInspector.Modules.Tests/Reports/TaskProcessingAnalysisTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/TaskProcessingAnalysisTests.cs
@@ -43,6 +43,12 @@ namespace KInspector.Tests.Common.Reports
         [Test]
         public async Task Should_ReturnWarningResult_When_ThereAreUnprocessedIntegrationBusTasks()
         {
+            if (_mockInstanceDetails?.AdministrationDatabaseVersion?.Major > 13)
+            {
+                // Integration bus is not present in XbK
+                return;
+            }
+
             // Arrange
             SetupAllDatabaseQueries(unprocessedIntegrationBusTasks: 1);
 
@@ -71,6 +77,12 @@ namespace KInspector.Tests.Common.Reports
         [Test]
         public async Task Should_ReturnWarningResult_When_ThereAreUnprocessedSearchTasks()
         {
+            if (_mockInstanceDetails?.AdministrationDatabaseVersion?.Major > 13)
+            {
+                // Search tasks not present in XbK
+                return;
+            }
+
             // Arrange
             SetupAllDatabaseQueries(unprocessedSearchTasks: 1);
 
@@ -85,6 +97,12 @@ namespace KInspector.Tests.Common.Reports
         [Test]
         public async Task Should_ReturnWarningResult_When_ThereAreUnprocessedStagingTasks()
         {
+            if (_mockInstanceDetails?.AdministrationDatabaseVersion?.Major > 13)
+            {
+                // Staging tasks are not present in XbK
+                return;
+            }
+
             // Arrange
             SetupAllDatabaseQueries(unprocessedStagingTasks: 1);
 
@@ -131,6 +149,9 @@ namespace KInspector.Tests.Common.Reports
 
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedScheduledTasks))
+                .Returns(Task.FromResult(unprocessedScheduledTasks));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFileScalar<int>(Scripts.GetCountOfUnprocessedScheduledTasksXbK))
                 .Returns(Task.FromResult(unprocessedScheduledTasks));
 
             _mockDatabaseService

--- a/test/KInspector.Modules.Tests/Reports/TaskProcessingAnalysisTests.cs
+++ b/test/KInspector.Modules.Tests/Reports/TaskProcessingAnalysisTests.cs
@@ -1,6 +1,7 @@
 using KInspector.Core.Constants;
 using KInspector.Reports.TaskProcessingAnalysis;
 using KInspector.Reports.TaskProcessingAnalysis.Models;
+using KInspector.Tests.Common.Helpers;
 
 using NUnit.Framework;
 
@@ -10,13 +11,20 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class TaskProcessingAnalysisTests : AbstractModuleTest<Report, Terms>
     {
         private readonly Report _mockReport;
 
         public TaskProcessingAnalysisTests(int majorVersion) : base(majorVersion)
         {
-            _mockReport = new Report(_mockDatabaseService.Object, _mockModuleMetadataService.Object);
+            var mockInstance = MockInstances.Get(majorVersion) ?? throw new InvalidOperationException($"No instance found with major version {majorVersion}.");
+            var mockInstanceDetails = MockInstanceDetails.Get(majorVersion) ?? throw new InvalidOperationException($"No instance details found with major version {majorVersion}.");
+            var mockInstanceService = MockInstanceServiceHelper.SetupInstanceService(mockInstance, mockInstanceDetails);
+            var mockConfigService = MockConfigServiceHelper.SetupMockConfigService(mockInstance);
+
+            _mockReport = new Report(_mockDatabaseService.Object, mockInstanceService.Object, mockConfigService.Object, _mockModuleMetadataService.Object);
         }
 
         [Test]

--- a/test/KInspector.Modules.Tests/Reports/UnusedPageTypeSummaryTest.cs
+++ b/test/KInspector.Modules.Tests/Reports/UnusedPageTypeSummaryTest.cs
@@ -35,6 +35,9 @@ namespace KInspector.Tests.Common.Reports
             _mockDatabaseService
                 .Setup(p => p.ExecuteSqlFromFile<PageType>(Scripts.GetUnusedPageTypes))
                 .Returns(Task.FromResult(unusedPageTypes));
+            _mockDatabaseService
+                .Setup(p => p.ExecuteSqlFromFile<PageType>(Scripts.GetUnusedPageTypesXbK))
+                .Returns(Task.FromResult(unusedPageTypes));
 
             // Act
             var results = await _mockReport.GetResults();

--- a/test/KInspector.Modules.Tests/Reports/UnusedPageTypeSummaryTest.cs
+++ b/test/KInspector.Modules.Tests/Reports/UnusedPageTypeSummaryTest.cs
@@ -1,6 +1,7 @@
 ﻿using KInspector.Core.Constants;
 using KInspector.Reports.UnusedPageTypeSummary;
 using KInspector.Reports.UnusedPageTypeSummary.Models;
+using KInspector.Tests.Common.Helpers;
 
 using NUnit.Framework;
 
@@ -10,13 +11,20 @@ namespace KInspector.Tests.Common.Reports
     [TestFixture(11)]
     [TestFixture(12)]
     [TestFixture(13)]
+    [TestFixture(30)]
+    [TestFixture(31)]
     public class UnusedPageTypeSummaryTest : AbstractModuleTest<Report, Terms>
     {
         private readonly Report _mockReport;
 
         public UnusedPageTypeSummaryTest(int majorVersion) : base(majorVersion)
         {
-            _mockReport = new Report(_mockDatabaseService.Object, _mockModuleMetadataService.Object);
+            var mockInstance = MockInstances.Get(majorVersion) ?? throw new InvalidOperationException($"No instance found with major version {majorVersion}.");
+            var mockInstanceDetails = MockInstanceDetails.Get(majorVersion) ?? throw new InvalidOperationException($"No instance details found with major version {majorVersion}.");
+            var mockInstanceService = MockInstanceServiceHelper.SetupInstanceService(mockInstance, mockInstanceDetails);
+            var mockConfigService = MockConfigServiceHelper.SetupMockConfigService(mockInstance);
+
+            _mockReport = new Report(_mockDatabaseService.Object, mockInstanceService.Object, _mockModuleMetadataService.Object, mockConfigService.Object);
         }
 
         [Test]

--- a/test/KInspector.Tests.Common/Helpers/MockInstanceDetails.cs
+++ b/test/KInspector.Tests.Common/Helpers/MockInstanceDetails.cs
@@ -75,8 +75,8 @@ namespace KInspector.Tests.Common.Helpers
                 11 => Kentico11,
                 12 => Kentico12,
                 13 => Kentico13,
-                30 => Kentico13,
-                31 => Kentico13,
+                30 => XbK30,
+                31 => XbK31,
                 _ => throw new NotImplementedException(),
             };
 

--- a/test/KInspector.Tests.Common/Helpers/MockInstanceDetails.cs
+++ b/test/KInspector.Tests.Common/Helpers/MockInstanceDetails.cs
@@ -54,6 +54,18 @@ namespace KInspector.Tests.Common.Helpers
             }
         };
 
+        public static InstanceDetails XbK30 = new()
+        {
+            AdministrationVersion = new Version("30.0"),
+            AdministrationDatabaseVersion = new Version("30.0")
+        };
+
+        public static InstanceDetails XbK31 = new()
+        {
+            AdministrationVersion = new Version("31.0"),
+            AdministrationDatabaseVersion = new Version("31.0")
+        };
+
         public static InstanceDetails Get(int majorVersion)
         {
             InstanceDetails? instanceDetails = majorVersion switch
@@ -63,6 +75,8 @@ namespace KInspector.Tests.Common.Helpers
                 11 => Kentico11,
                 12 => Kentico12,
                 13 => Kentico13,
+                30 => Kentico13,
+                31 => Kentico13,
                 _ => throw new NotImplementedException(),
             };
 

--- a/test/KInspector.Tests.Common/Helpers/MockInstances.cs
+++ b/test/KInspector.Tests.Common/Helpers/MockInstances.cs
@@ -44,23 +44,35 @@ namespace KInspector.Tests.Common.Helpers
             AdministrationUrl = "http://kentico13.com"
         };
 
+        public static Instance XbK30 = new()
+        {
+            Name = "XbK 30 Test Instance",
+            Guid = Guid.NewGuid(),
+            AdministrationPath = "C:\\inetpub\\wwwroot\\XbK30",
+            AdministrationUrl = "http://xbk30.com"
+        };
+
+        public static Instance XbK31 = new()
+        {
+            Name = "XbK 31 Test Instance",
+            Guid = Guid.NewGuid(),
+            AdministrationPath = "C:\\inetpub\\wwwroot\\XbK31",
+            AdministrationUrl = "http://xbk31.com"
+        };
+
         public static Instance Get(int majorVersion)
         {
-            switch (majorVersion)
+            return majorVersion switch
             {
-                case 9:
-                    return Kentico9;
-                case 10:
-                    return Kentico10;
-                case 11:
-                    return Kentico11;
-                case 12:
-                    return Kentico12;
-                case 13:
-                    return Kentico13;
-                default:
-                    throw new NotImplementedException();
-            }
+                9 => Kentico9,
+                10 => Kentico10,
+                11 => Kentico11,
+                12 => Kentico12,
+                13 => Kentico13,
+                30 => XbK30,
+                31 => XbK31,
+                _ => throw new NotImplementedException(),
+            };
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Sets proper supported/unsupported status of actions/reports for Xbk 30/31
- Migrates "Class/table validation" report to XbK
- Migrates "Page type field analysis" report to XbK
- Migrates "Task processing analysis" report to XbK
- Migrates "Unused page type summary" report to XbK

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults
